### PR TITLE
feat: 添加Postal发信驱动

### DIFF
--- a/app/Http/Controllers/V1/Admin/ConfigController.php
+++ b/app/Http/Controllers/V1/Admin/ConfigController.php
@@ -128,7 +128,9 @@ class ConfigController extends Controller
                 'email_username' => admin_setting('email_username'),
                 'email_password' => admin_setting('email_password'),
                 'email_encryption' => admin_setting('email_encryption'),
-                'email_from_address' => admin_setting('email_from_address')
+                'email_from_address' => admin_setting('email_from_address'),
+                'email_postal_host' => admin_setting('email_postal_host'),
+                'email_postal_key' => admin_setting('email_postal_key'),
             ],
             'telegram' => [
                 'telegram_bot_enable' => admin_setting('telegram_bot_enable', 0),
@@ -188,7 +190,7 @@ class ConfigController extends Controller
                 );
             }
         }
-        
+
         Cache::forget('admin_settings');
         // \Artisan::call('horizon:terminate'); //重启队列使配置生效
         return $this->success(true);

--- a/app/Http/Requests/Admin/ConfigSave.php
+++ b/app/Http/Requests/Admin/ConfigSave.php
@@ -62,6 +62,8 @@ class ConfigSave extends FormRequest
         'email_password' => '',
         'email_encryption' => '',
         'email_from_address' => '',
+        'email_postal_host' => '',
+        'email_postal_key' => '',
         // telegram
         'telegram_bot_enable' => 'in:0,1',
         'telegram_bot_token' => '',

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "nunomaduro/collision": "^7.10",
         "paragonie/sodium_compat": "^1.20",
         "php-curl-class/php-curl-class": "^8.6",
+        "postal/postal": "^2.0",
         "spatie/db-dumper": "^3.4",
         "stripe/stripe-php": "^7.36.1",
         "symfony/http-client": "^6.4",


### PR DESCRIPTION
在后端实现通过Postal API发送邮件，当`email_host`为空且`email_postal_host`不为空时，则切换为Postal发信
前端未添加相关设置，因为没找到源码，未经充分测试