### PR TITLE
fix: 流量排行最多显示15个

### DIFF
--- a/app/Http/Controllers/V1/Admin/StatController.php
+++ b/app/Http/Controllers/V1/Admin/StatController.php
@@ -128,7 +128,7 @@ class StatController extends Controller
         }
         array_multisort(array_column($statistics, 'total'), SORT_DESC, $statistics);
         return [
-            'data' => $statistics
+            'data' => array_splice($statistics, 0, 15)
         ];
     }
     // 获取昨日节点流量排行

--- a/app/Services/StatisticalService.php
+++ b/app/Services/StatisticalService.php
@@ -154,8 +154,8 @@ class StatisticalService {
                     $stats[] = [
                         'server_id' => $serverId,
                         'server_type' => $serverType,
-                        'u' => $v[$serverId][0],
-                        'd' => $v[$serverId][1],
+                        'u' => $v[$serverId][0] ?: 0,
+                        'd' => $v[$serverId][1] ?: 0,
                     ];
                 }
             }


### PR DESCRIPTION
如果多了，前端显示会炸。