### PR TITLE
fix: Hysteria2's speed error

### DIFF
--- a/app/Protocols/ClashMeta.php
+++ b/app/Protocols/ClashMeta.php
@@ -281,8 +281,8 @@ class ClashMeta
         $array['server'] = $server['host'];
         $array['port'] = $server['port'];
         if($server['server_name']) $array['sni'] = $server['server_name'];
-        $array['up'] = $user->speed_limit ? min($server['up_mbps'], $user->speed_limit) : $server['up_mbps'];
-        $array['down'] = $user->speed_limit ? min($server['down_mbps'], $user->speed_limit) : $server['down_mbps'];
+        $array['up'] = $user->speed_limit ? min($server['down_mbps'], $user->speed_limit) : $server['down_mbps'];
+        $array['down'] = $user->speed_limit ? min($server['up_mbps'], $user->speed_limit) : $server['up_mbps'];
         $array['skip-cert-verify'] = $server['insecure'] ? true : false;
         switch($server['version']){
             case 1: 


### PR DESCRIPTION
This PR fixes the issue where Hysteria2's upstream and downstream speeds were written backwards in ClashMeta client.
The code is correct at [here](https://github.com/cedar2025/Xboard/blob/72fb7031e52ae1b8919ed03a48de7dff5e87ea35/app/Protocols/SingBox.php#L283).
It looks like the code is also wrong in other clients, but I'm not in a position to test it cuz I don't have those clients.