### PR TITLE
fix: 修复用户侧流量明细不显示的问题

### DIFF
--- a/app/Http/Controllers/V1/User/StatController.php
+++ b/app/Http/Controllers/V1/User/StatController.php
@@ -13,7 +13,7 @@ class StatController extends Controller
 {
     public function getTrafficLog(Request $request)
     {
-        $startDate = now()->startOfMonth();
+        $startDate = strtotime(now()->startOfMonth());
         $records = StatUser::query()
             ->where('user_id', $request->user['id'])
             ->where('record_at', '>=', $startDate)
@@ -26,11 +26,11 @@ class StatController extends Controller
         $statService->setStartAt($recordAt);
         $todayTraffics = $statService->getStatUserByUserID($request->user['id']);
         if (count($todayTraffics) > 0) {
-            $todayTraffics = collect($todayTraffics)->map(function ($todayTraffic) {
-                $todayTraffic['server_rate'] = number_format($todayTraffic['server_rate'], 2);
-                return $todayTraffic;
+            $records = collect($todayTraffics)->merge($records);
+            $records = $records->map(function ($record) {
+                $record['server_rate'] = number_format($record['server_rate'], 2);
+                return $record;
             });
-            $records = $todayTraffics->merge($records);
         }
         $data = TrafficLogResource::collection(collect($records));
         return $this->success($data);

--- a/app/Services/StatisticalService.php
+++ b/app/Services/StatisticalService.php
@@ -110,12 +110,11 @@ class StatisticalService
      */
     public function getStatUserByUserID($userId): array
     {
-
         $stats = [];
         $statsUser = $this->redis->zrange($this->statUserKey, 0, -1, true);
         foreach ($statsUser as $member => $value) {
             list($rate, $uid, $type) = explode('_', $member);
-            if ($uid !== $userId)
+            if (intval($uid) !== intval($userId))
                 continue;
             $key = "{$rate}_{$uid}";
             $stats[$key] = $stats[$key] ?? [


### PR DESCRIPTION
部署后发现用户侧流量明细始终显示为空，调试发现如下问题并简单进行了修复：
* `now()->startOfMonth()`返回的是时间而非时间戳，导致无法获取月初至今的流量明细
* `$uid`和`$userId`类型不同，故`$uid !== $userId`将会始终返回`false`，导致无法获取当日的流量明细