### PR TITLE
Feat: login with mail link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,17 @@ FROM phpswoole/swoole:php8.1-alpine
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 
-RUN install-php-extensions pcntl bcmath inotify \ 
-&& apk --no-cache add shadow supervisor nginx sqlite nginx-mod-http-brotli mysql-client git patch \
-&& addgroup -S -g 1000 www && adduser -S -G www -u 1000 www 
-#复制项目文件以及配置文件
+RUN install-php-extensions pcntl bcmath inotify \
+        && apk --no-cache add shadow supervisor nginx sqlite nginx-mod-http-brotli mysql-client git patch \
+        && addgroup -S -g 1000 www && adduser -S -G www -u 1000 www
+
+# 复制项目文件以及配置文件
 WORKDIR /www
 COPY .docker /
 COPY . /www
 RUN composer install --optimize-autoloader --no-cache --no-dev \
-&& php artisan storage:link \
-&& chown -R www:www /www \
-&& chmod -R 775 /www
+        && php artisan storage:link \
+        && chown -R www:www /www \
+        && chmod -R 775 /www
 
 CMD  /usr/bin/supervisord --nodaemon -c /etc/supervisor/supervisord.conf

--- a/app/Http/Controllers/V2/Passport/AuthController.php
+++ b/app/Http/Controllers/V2/Passport/AuthController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\V2\Passport;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\SendEmailJob;
+use App\Models\User;
+use App\Utils\CacheKey;
+use App\Utils\Helper;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+
+class AuthController extends Controller
+{
+    /**
+     * Send login link to email
+     *
+     * @param Request $request
+     * @return JsonResponse
+     * @api POST /api/v2/auth/magicLogin
+     */
+    public function magicLogin(Request $request)
+    {
+        $params = $request->validate([
+            'email' => 'required|email:strict',
+            'redirect' => 'nullable'
+        ]);
+
+        if (Cache::get(CacheKey::get('LAST_SEND_LOGIN_WITH_MAIL_LINK_TIMESTAMP', $params['email']))) {
+            return $this->fail([429, __('Sending frequently, please try again later')]);
+        }
+        Cache::put(CacheKey::get('LAST_SEND_LOGIN_WITH_MAIL_LINK_TIMESTAMP', $params['email']), time(), 60); // 1 minute
+
+        $user = User::where('email', $params['email'])->first();
+        if (!$user) {
+            return $this->success(__('If the email exists, a login link will be sent to the email'));
+        }
+
+        $code = Helper::guid();
+        $key = CacheKey::get('TEMP_TOKEN', $code);
+        Cache::put($key, $user->id, 7 * 24 * 3600); // 7 days
+
+        $redirect = $request->input('redirect') ? $request->input('redirect') : 'dashboard';
+        $loginUrl = '/#/login?verify=' . $code . '&redirect=' . $redirect;
+        if (admin_setting('app_url')) {
+            $loginUrl = admin_setting('app_url') . $loginUrl;
+        } else {
+            $loginUrl = url($loginUrl);
+        }
+
+        // Send email
+        SendEmailJob::dispatch([
+            'email' => $user->email,
+            'subject' => __('Login to :name', [
+                'name' => admin_setting('app_name', 'XBoard')
+            ]),
+            'template_name' => 'mailLogin',
+            'template_value' => [
+                'name' => admin_setting('app_name', 'XBoard'),
+                'link' => $loginUrl,
+                'url' => admin_setting('app_url')
+            ]
+        ]);
+
+        return $this->success(__('If the email exists, a login link will be sent to the email'));
+    }
+}

--- a/app/Http/Routes/V2/AdminRoute.php
+++ b/app/Http/Routes/V2/AdminRoute.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Http\Routes\V2;
 
 use Illuminate\Contracts\Routing\Registrar;
@@ -12,9 +13,9 @@ class AdminRoute
             'middleware' => ['admin', 'log'],
         ], function ($router) {
             // Stat
-            $router->get ('/stat/override', 'V2\\Admin\\StatController@override');
-            $router->get ('/stat/record', 'V2\\Admin\\StatController@record');
-            $router->get ('/stat/ranking', 'V2\\Admin\\StatController@ranking');
+            $router->get('/stat/override', 'V2\\Admin\\StatController@override');
+            $router->get('/stat/record', 'V2\\Admin\\StatController@record');
+            $router->get('/stat/ranking', 'V2\\Admin\\StatController@ranking');
         });
     }
 }

--- a/app/Http/Routes/V2/PassportRoute.php
+++ b/app/Http/Routes/V2/PassportRoute.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Routes\V2;
+
+use Illuminate\Contracts\Routing\Registrar;
+
+class PassportRoute
+{
+    public function map(Registrar $router)
+    {
+        $router->group([
+            'prefix' => 'passport'
+        ], function ($router) {
+            // Auth
+            $router->post('/auth/magicLogin', 'V2\\Passport\\AuthController@magicLogin');
+        });
+    }
+}

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -12,9 +12,9 @@ services:
     ports:
       - "6379:6379"
     networks:
-        - app-network
+      - app-network
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s
 
   mariadb:
@@ -42,3 +42,4 @@ services:
       - app-network
     volumes:
       - xboard-config:/www/config
+      - ./:/www

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,44 @@
+name: xboard-dev
+
+networks:
+  app-network:
+
+volumes:
+  xboard-config:
+
+services:
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    networks:
+        - app-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+
+  mariadb:
+    image: mariadb:10.6
+    ports:
+      - "3306:3306"
+    networks:
+      - app-network
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: xboard
+      MYSQL_USER: xboard
+      MYSQL_PASSWORD: xboard
+
+  xboard:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - redis
+      - mariadb
+    ports:
+      - "7001:7001"
+    networks:
+      - app-network
+    volumes:
+      - xboard-config:/www/config

--- a/docker-compose.sample.yaml
+++ b/docker-compose.sample.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   xboard:
-    # build: 
+    # build:
     #   context: .
     image: ghcr.io/cedar2025/xboard:latest
     volumes:
@@ -17,7 +17,7 @@ services:
     # ports:
     #   - 7001:7001
   redis:
-    build: 
+    build:
       context: .docker/services/redis
     restart: always
     volumes:


### PR DESCRIPTION
Created new API `POST /api/v2/auth/magicLogin`.

Accepting parameters:
- `email` required, user's email address.
- `redirect` optional, redirect target.

Response:
```json
{
    "status": "success",
    "message": "操作成功",
    "data": "If the email exists, a login link will be sent to the email",
    "error": null
}
```

This operation will send an email to the user's mailbox with the login URL. The URL contains the verify parameter, which is verified by frontend. The frontend requests `POST /api/v1/auth/token2Login` with the parameter `verify`, and the back-end returns auth data, refer to /app/Http/Controllers/V1/Passport/AuthController.php:288, which is a old v2board logic.

The old version of the `POST /api/v1/auth/loginWithMailLink` method in v2board requires admin to configure the setting `login_with_mail_link_enable`, which does not actually exist in admin management frontend. The new version removes this method, but the system must be correctly configured to send email in SMTP.