### PR TITLE
feat: change listening address to all network interfaces

### DIFF
--- a/webman.php
+++ b/webman.php
@@ -9,7 +9,7 @@ use \Workerman\Events\EventInterface;
 define('Workerman', true);
 
 Adapterman::init();
-$http_worker = new Worker('http://127.0.0.1:7010');
+$http_worker = new Worker('http://0.0.0.0:7010');
 $http_worker->count = getenv('WEBMAN_WORKERS') ?: max(swoole_cpu_num(), 2);
 $http_worker->name = 'Xboard';
 $http_worker->onWorkerStart = static function () {


### PR DESCRIPTION
- Updated the listening port address from local interface to all interfaces to support access from multiple networks

> 用于解决在 Kubernetes 部署时，探测检查一直失败。由于监听 127.0.0.1，导致 Pod IP 探测一直 TCP Close，本机部署时可考虑防火墙和安全组保护。
> 
> 若有其他影响，可在下方讨论。