### PR TITLE
Fixed Multiplt Vmess+TCP bugs for shadowrocket

### DIFF
--- a/app/Protocols/Shadowrocket.php
+++ b/app/Protocols/Shadowrocket.php
@@ -96,8 +96,11 @@ class Shadowrocket implements ProtocolInterface
 
         switch (data_get($protocol_settings, 'network')) {
             case 'tcp':
-                $config['obfs'] = data_get($protocol_settings, 'network_settings.header.type');
-                $config['path'] = \Arr::random(data_get($protocol_settings, 'network_settings.header.request.path', ['/']));
+                if (data_get($protocol_settings, 'network_settings.header.type', 'none') !== 'none') {
+                    $config['obfs'] = data_get($protocol_settings, 'network_settings.header.type');
+                    $config['path'] = \Arr::random(data_get($protocol_settings, 'network_settings.header.request.path', ['/']));
+                    $config['obfsParam'] = \Arr::random(data_get($protocol_settings, 'network_settings.header.request.headers.Host', ['www.example.com']));
+                }
                 break;
             case 'ws':
                 $config['obfs'] = "websocket";
@@ -161,13 +164,18 @@ class Shadowrocket implements ProtocolInterface
         }
         switch (data_get($protocol_settings, 'network')) {
             case 'tcp':
-                $config['obfs'] = data_get($protocol_settings, 'network_settings.header.type');
-                $config['path'] = \Arr::random(data_get($protocol_settings, 'network_settings.header.request.path', ['/']));
-                $config['obfsParam'] = \Arr::random(data_get($protocol_settings, 'network_settings.header.request.headers.Host', ['/']));
+                if (data_get($protocol_settings, 'network_settings.header.type', 'none') !== 'none') {
+                    $config['obfs'] = data_get($protocol_settings, 'network_settings.header.type');
+                    $config['path'] = \Arr::random(data_get($protocol_settings, 'network_settings.header.request.path', ['/']));
+                    $config['obfsParam'] = \Arr::random(data_get($protocol_settings, 'network_settings.header.request.headers.Host', ['www.example.com']));
+                }
                 break;
             case 'ws':
                 $config['obfs'] = "websocket";
-                $config['path'] = data_get($protocol_settings, 'network_settings.path');
+                if (data_get($protocol_settings, 'network_settings.path')) {
+                    $config['path'] = data_get($protocol_settings, 'network_settings.path');
+                }
+
                 if ($host = data_get($protocol_settings, 'network_settings.headers.Host')) {
                     $config['obfsParam'] = $host;
                 }

--- a/app/Protocols/Shadowrocket.php
+++ b/app/Protocols/Shadowrocket.php
@@ -97,7 +97,7 @@ class Shadowrocket implements ProtocolInterface
         switch (data_get($protocol_settings, 'network')) {
             case 'tcp':
                 $config['obfs'] = data_get($protocol_settings, 'network_settings.header.type');
-                $config['path'] = \Arr::ra(data_get($protocol_settings, 'network_settings.header.request.path', ['/']));
+                $config['path'] = \Arr::random(data_get($protocol_settings, 'network_settings.header.request.path', ['/']));
                 break;
             case 'ws':
                 $config['obfs'] = "websocket";


### PR DESCRIPTION
1. unverified network_settings header type
2. websocket unverified path
3. network_settings.header.request.headers.Host shall be ['www.example.com'] instead of ['/']