### PR TITLE
The plan title will now be passed to EPay as the product

### DIFF
--- a/app/Http/Controllers/V1/User/OrderController.php
+++ b/app/Http/Controllers/V1/User/OrderController.php
@@ -179,10 +179,13 @@ class OrderController extends Controller
         $order->payment_id = $method;
         if (!$order->save())
             return $this->fail([400, __('Request failed, please try again later')]);
+        $plan = Plan::find($order->plan_id);
+        $plan_name = $plan->name;
         $result = $paymentService->pay([
             'trade_no' => $tradeNo,
             'total_amount' => isset($order->handling_amount) ? ($order->total_amount + $order->handling_amount) : $order->total_amount,
             'user_id' => $order->user_id,
+            'plan_name' => $plan_name,
             'stripe_token' => $request->input('token')
         ]);
         return response([

--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -50,6 +50,7 @@ class PaymentService
             'notify_url' => $notifyUrl,
             'return_url' => url('/#/order/' . $order['trade_no']),
             'trade_no' => $order['trade_no'],
+            'plan_name' => $order['plan_name'],
             'total_amount' => $order['total_amount'],
             'user_id' => $order['user_id'],
             'stripe_token' => $order['stripe_token']


### PR DESCRIPTION
Instead of passing the trade number for the product too, the plan title is now passed to epay as the product correctly. Now you can finally have a better overview of your orders in epay!