### PR TITLE
Fix the bug of sub-node ss password mismatch

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -276,7 +276,9 @@ class Server extends Model
         }
 
         $config = self::CIPHER_CONFIGURATIONS[$cipher];
-        $serverKey = Helper::getServerKey($this->created_at, $config['serverKeySize']);
+        // Use parent's created_at if this is a child node
+        $serverCreatedAt = $this->parent_id ? $this->parent->created_at : $this->created_at;
+        $serverKey = Helper::getServerKey($serverCreatedAt, $config['serverKeySize']);
         $userKey = Helper::uuidToBase64($user->uuid, $config['userKeySize']);
         return "{$serverKey}:{$userKey}";
     }


### PR DESCRIPTION
generateShadowsocksPassword 存在bug，除非用复制功能创建节点，否则将导致子节点的密码和父节点的密码不一致而无法正常链接。