### PR TITLE
feat(Provider): Add Shadowrocket support for VLESS+xhttp/httpupgrade

### DIFF
--- a/app/Protocols/Shadowrocket.php
+++ b/app/Protocols/Shadowrocket.php
@@ -199,6 +199,27 @@ class Shadowrocket extends AbstractProtocol
                 $config['path'] = data_get($protocol_settings, 'network_settings.serviceName');
                 $config['host'] = data_get($protocol_settings, 'tls_settings.server_name') ?? $server['host'];
                 break;
+            case 'httpupgrade':
+                $config['obfs'] = "httpupgrade";
+                if (data_get($protocol_settings, 'network_settings.path')) {
+                    $config['path'] = data_get($protocol_settings, 'network_settings.path');
+                }
+        
+                if ($host = data_get($protocol_settings, 'network_settings.host')) {
+                    $config['obfsParam'] = $host;
+                }
+                break;           
+            case 'xhttp':
+                $config['obfs'] = "xhttp";
+                if (data_get($protocol_settings, 'network_settings.path')) {
+                    $config['path'] = data_get($protocol_settings, 'network_settings.path');
+                }
+        
+                if ($host = data_get($protocol_settings, 'network_settings.host')) {
+                    $obfsParam = ['Host' => $host];
+                    $config['obfsParam'] = json_encode($obfsParam);
+                }
+                break;                                                      
         }
 
         $query = http_build_query($config, '', '&', PHP_QUERY_RFC3986);


### PR DESCRIPTION
### 🚀 功能描述

本次提交为 Shadowrocket (小火箭) 订阅生成器添加了对 **VLESS + xhttp** 和 **VLESS + httpupgrade** 这两种传输方式的支持。

---

### 💡 动机 

当前版本的 `Shadowrocket.php` 无法为使用 `xhttp` 或 `httpupgrade` 传输协议的 VLESS 节点生成兼容的订阅链接。

这导致用户即使在面板后台正确配置了节点，也无法在小火箭中正常导入和使用，限制了用户对新传输协议的选择。本次修改旨在解决此问题，完善订阅功能。

---

### 🛠️ 实现方式

-   在 `buildVless` 方法中，为网络传输的 `switch` 语句增加了 `httpupgrade` 的 `case`。
-   同样地，增加了对 `xhttp` 的 `case`。
-   针对 `xhttp` 协议，根据小火箭的解析规范，将 `Host` 参数通过 `json_encode` 函数格式化为 JSON 字符串 (例如 `{"Host":"..."}`)，并赋值给 `obfsParam`，以确保客户端能正确识别。

---

### ✅ 测试方法

1.  在 Xboard 面板后台，创建一个 VLESS 节点，并将其网络传输方式设置为 `xhttp` (或 `httpupgrade`)。
2.  为该节点配置好路径 (`path`) 和伪装域名 (`host`)。
3.  生成小火箭订阅链接。
4.  将订阅链接导入最新版本的小火箭 App 中。
5.  节点可以被正常识别并成功连接。**我已在自己的环境中完成测试，功能正常。**