### PR TITLE
fix: missing field 'version' when distributing tuic protocol in stash

### DIFF
--- a/app/Protocols/Stash.php
+++ b/app/Protocols/Stash.php
@@ -405,6 +405,7 @@ class Stash extends AbstractProtocol
             'heartbeat-interval' => 10000,
             'request-timeout' => 8000,
             'max-udp-relay-packet-size' => 1500,
+            'version' => data_get($protocol_settings, 'version', 5),
         ];
 
         $array['skip-cert-verify'] = (bool) data_get($protocol_settings, 'tls.allow_insecure', false);


### PR DESCRIPTION
stash下发tuic协议时缺少version字段，会导致订阅无法使用
![image.png](https://img.imgdd.com/a5b0ef23-c17c-4350-adde-affba6d91163.png)