### PR TITLE
Add missing extension

### DIFF
--- a/docs/en/installation/aapanel.md
+++ b/docs/en/installation/aapanel.md
@@ -46,6 +46,7 @@ Required PHP extensions:
 - swoole
 - readline
 - event
+- mbstring
 
 #### 2.3 Enable Required PHP Functions
 Functions that need to be enabled:


### PR DESCRIPTION
Fix: Call to undefined function Illuminate\Support\mb_split()