### PR TITLE
fix(theme): 调整脚本加载顺序以修复配置读取问题

### DIFF
--- a/theme/Xboard/index.html
+++ b/theme/Xboard/index.html
@@ -1,1 +1,16 @@
-<!doctype html><html lang="zh-CN"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"><title>Xboard</title><script type="module" crossorigin src="/assets/umi.js"></script></head><body><script src="./env.js"></script><div id="app"></div></body></html>
+<!doctype html>
+<html lang="zh-CN">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Xboard</title>
+    <script src="./env.js"></script>
+    <script type="module" crossorigin src="/assets/umi.js"></script>
+</head>
+
+<body>
+    <div id="app"></div>
+</body>
+
+</html>


### PR DESCRIPTION
之前脚本的加载顺序导致在前后端分离主题中，配置无法在主题脚本之前加载，从而导致配置读取失败。此更改确保配置优先加载。