### PR TITLE
fix: correct SNI domain configuration paths in SingBox protocol

### DIFF
--- a/app/Protocols/SingBox.php
+++ b/app/Protocols/SingBox.php
@@ -310,7 +310,7 @@ class SingBox extends AbstractProtocol
                 'insecure' => (bool) data_get($protocol_settings, 'allow_insecure', false),
             ]
         ];
-        if ($serverName = data_get($protocol_settings, 'tls_settings.server_name')) {
+        if ($serverName = data_get($protocol_settings, 'server_name')) {
             $array['tls']['server_name'] = $serverName;
         }
         $transport = match (data_get($protocol_settings, 'network')) {
@@ -353,7 +353,7 @@ class SingBox extends AbstractProtocol
             }
         }
 
-        if ($serverName = data_get($protocol_settings, 'tls_settings.server_name')) {
+        if ($serverName = data_get($protocol_settings, 'tls.server_name')) {
             $baseConfig['tls']['server_name'] = $serverName;
         }
         $speedConfig = [

--- a/app/Protocols/SingBox.php
+++ b/app/Protocols/SingBox.php
@@ -193,10 +193,10 @@ class SingBox extends AbstractProtocol
         }
 
         $transport = match ($protocol_settings['network']) {
-            'tcp' => [
+            'tcp' => data_get($protocol_settings, 'network_settings.header.type', 'none') !== 'none' ? [
                 'type' => 'http',
                 'path' => Arr::random(data_get($protocol_settings, 'network_settings.header.request.path', ['/']))
-            ],
+            ] : null,
             'ws' => [
                 'type' => 'ws',
                 'path' => data_get($protocol_settings, 'network_settings.path'),


### PR DESCRIPTION
- Fix Trojan protocol to use 'server_name' instead of 'tls_settings.server_name'
- Fix Hysteria protocol to use 'tls.server_name' instead of 'tls_settings.server_name'
- Align with Server model configuration and General protocol implementation
- Resolves missing SNI domains in sing-box configuration generation

This fixes the inconsistency where SNI domains were missing for certain protocols while working correctly in General protocol handler.