### PR TITLE
Fix: Stash VLESS/VMESS TCP/HTTP disguise node generation rules

### DIFF
--- a/app/Protocols/Stash.php
+++ b/app/Protocols/Stash.php
@@ -251,10 +251,15 @@ class Stash extends AbstractProtocol
 
         switch (data_get($protocol_settings, 'network')) {
             case 'tcp':
-                $array['network'] = data_get($protocol_settings, 'network_settings.header.type', 'http');
-                $array['http-opts']['path'] = data_get($protocol_settings, 'network_settings.header.request.path', ['/']);
-                if ($host = data_get($protocol_settings, 'network_settings.header.request.headers.Host')) {
-                    $array['http-opts']['headers']['Host'] = $host;
+                $headerType = data_get($protocol_settings, 'network_settings.header.type', 'tcp');
+                if ($headerType === 'tcp' || $headerType === '' || $headerType === 'none') {
+                    $array['network'] = 'tcp';
+                } elseif ($headerType === 'http') {
+                    $array['network'] = 'http';
+                    $array['http-opts']['path'] = data_get($protocol_settings, 'network_settings.header.request.path', ['/']);
+                    if ($host = data_get($protocol_settings, 'network_settings.header.request.headers.Host')) {
+                        $array['http-opts']['headers']['Host'] = $host;
+                    }
                 }
                 break;
             case 'ws':


### PR DESCRIPTION
This PR fixes the logic for generating VLESS/VMESS nodes as follows:
- When network is tcp, check the header.type field:
  - If header.type is empty, none, or tcp, set network to tcp
  - If header.type is http, set network to http and add the http-opts field
- Other protocol logic remains unchanged
This change ensures that the generated node templates are compatible with the latest Stash rules, supporting both TCP and HTTP disguise scenarios.