### PR TITLE
fix vless tcp network:true

### DIFF
--- a/app/Protocols/Stash.php
+++ b/app/Protocols/Stash.php
@@ -312,7 +312,8 @@ class Stash extends AbstractProtocol
 
         switch (data_get($protocol_settings, 'network')) {
             case 'tcp':
-                if ($headerType = data_get($protocol_settings, 'network_settings.header.type', 'tcp') != 'tcp') {
+                $headerType = data_get($protocol_settings, 'network_settings.header.type', 'tcp');
+                if ($headerType != 'tcp') {
                     $array['network'] = $headerType;
                     if ($httpOpts = array_filter([
                         'headers' => data_get($protocol_settings, 'network_settings.header.request.headers'),


### PR DESCRIPTION
<img width="588" height="417" alt="image" src="https://github.com/user-attachments/assets/33909afe-9f99-4b79-b623-6e7e6f04a6b3" />
修复 vless 在纯TCP传输协议下，stash下发network:true导致配置无法加载

安全性 无
传输协议 TCP
流控 none