### PR TITLE
fix: Type error when redeeming gift card

### DIFF
--- a/app/Services/GiftCardService.php
+++ b/app/Services/GiftCardService.php
@@ -173,7 +173,7 @@ class GiftCardService
                 $userService->assignPlan(
                     $this->user,
                     $plan,
-                    $rewards['plan_validity_days'] ?? null
+                    $rewards['plan_validity_days'] ?? 0
                 );
             }
         } else {


### PR DESCRIPTION
There is a type error when redeeming the gift card.
```
App\Services\UserService::assignPlan(): Argument #3 ($validityDays) must be of type int, null given, called in /www/app/Services/GiftCardService.php on line 173

File: /www/app/Services/UserService.php
Line: 239
```