### PR TITLE
feat: Add OR logic support to user fetch API filters

### DIFF
--- a/app/Http/Controllers/V2/Admin/UserController.php
+++ b/app/Http/Controllers/V2/Admin/UserController.php
@@ -63,10 +63,17 @@ class UserController extends Controller
         collect($request->input('filter'))->each(function ($filter) use ($builder) {
             $field = $filter['id'];
             $value = $filter['value'];
+            $logic = strtolower($filter['logic'] ?? 'and');
 
-            $builder->where(function ($query) use ($field, $value) {
-                $this->buildFilterQuery($query, $field, $value);
-            });
+            if ($logic === 'or') {
+                $builder->orWhere(function ($query) use ($field, $value) {
+                    $this->buildFilterQuery($query, $field, $value);
+                });
+            } else {
+                $builder->where(function ($query) use ($field, $value) {
+                    $this->buildFilterQuery($query, $field, $value);
+                });
+            }
         });
     }
 


### PR DESCRIPTION
## Summary

Added support for OR logic between filters in the user/fetch endpoint while maintaining full backward compatibility with existing API clients.

## Features
- Each filter can now specify a 'logic' parameter ('and' or 'or')
- Defaults to 'and' when not specified (backward compatible)
- Enables complex queries like finding users in multiple groups
- Supports mixing AND/OR conditions in a single request

## Examples

### Find users in multiple groups (OR logic)
```json
{
  "filter": [
    {
      "id": "group_id",
      "value": [1, 2, 3, 4],
      "logic": "or"
    }
  ]
}
```

### Find users with high traffic OR expired accounts
```json
{
  "filter": [
    {
      "id": "total_used",
      "value": "gt:107374182400"
    },
    {
      "id": "expired_at",
      "value": "lt:1706400000",
      "logic": "or"
    }
  ]
}
```

### Backward compatible (legacy format still works)
```json
{
  "filter": [
    {
      "id": "id",
      "value": "gt:13"
    },
    {
      "id": "total_used",
      "value": "gt:10737418240"
    }
  ]
}
```

## Changes
- Modified `applyFilters` method in `UserController.php` to support optional `logic` parameter
- When `logic` is not specified, defaults to 'and' (preserves existing behavior)
- When `logic: 'or'` is specified, uses `orWhere` instead of `where`

## Backward Compatibility
✅ All existing API calls continue to work without any changes
✅ Legacy frontends require no modifications
✅ Only new requests with explicit `logic: 'or'` will use OR logic