### PR TITLE
fix: add Hysteria2 Salamander obfs params to Surge/Stash/Loon subscriptions

### DIFF
--- a/app/Protocols/Loon.php
+++ b/app/Protocols/Loon.php
@@ -268,6 +268,10 @@ class Loon extends AbstractProtocol
         if (data_get($protocol_settings, 'tls.allow_insecure'))
             $config[] = "skip-cert-verify=true";
         $config[] = "download-bandwidth=" . data_get($protocol_settings, 'bandwidth.download_bandwidth');
+        if (data_get($protocol_settings, 'obfs.open') && data_get($protocol_settings, 'obfs.type') === 'salamander') {
+            $config[] = 'obfs=salamander';
+            $config[] = "obfs-password=" . data_get($protocol_settings, 'obfs.password');
+        }
         $config[] = "udp=true";
         $config = array_filter($config);
         $uri = implode(',', $config);

--- a/app/Protocols/Stash.php
+++ b/app/Protocols/Stash.php
@@ -404,6 +404,10 @@ class Stash extends AbstractProtocol
                 $array['type'] = 'hysteria2';
                 $array['auth'] = $password;
                 $array['fast-open'] = true;
+                if (data_get($protocol_settings, 'obfs.open')) {
+                    $array['obfs'] = data_get($protocol_settings, 'obfs.type');
+                    $array['obfs-password'] = data_get($protocol_settings, 'obfs.password');
+                }
                 break;
         }
         return $array;

--- a/app/Protocols/Surge.php
+++ b/app/Protocols/Surge.php
@@ -254,6 +254,10 @@ class Surge extends AbstractProtocol
         if (data_get($protocol_settings, 'tls.allow_insecure')) {
             $config[] = !!data_get($protocol_settings, 'tls.allow_insecure') ? 'skip-cert-verify=true' : 'skip-cert-verify=false';
         }
+        if (data_get($protocol_settings, 'obfs.open') && data_get($protocol_settings, 'obfs.type') === 'salamander') {
+            $config[] = 'obfs=salamander';
+            $config[] = "obfs-password=" . data_get($protocol_settings, 'obfs.password');
+        }
         $config = array_filter($config);
         $uri = implode(',', $config);
         $uri .= "\r\n";


### PR DESCRIPTION
## Summary

- Surge, Stash, and Loon subscription handlers were missing Salamander obfuscation parameters (`obfs=salamander` + `obfs-password`) for Hysteria2
- When `obfs.open=true` in protocol_settings, clients received configs without obfs params, causing protocol mismatch and connection failure
- ClashMeta, SingBox, Shadowrocket, and General handlers already handle this correctly — only Surge/Stash/Loon were affected

## Changes

- **Surge.php**: Add `obfs=salamander` and `obfs-password=xxx` to hy2 config output
- **Stash.php**: Add `obfs` and `obfs-password` to hy2 v2 case branch
- **Loon.php**: Add `obfs=salamander` and `obfs-password=xxx` to hy2 config output

## Test plan

- [x] Enable Salamander obfuscation on a Hysteria2 node (`obfs.open: true`)
- [x] Verify Surge subscription includes `obfs=salamander,obfs-password=xxx`
- [x] Verify Stash subscription includes `obfs` and `obfs-password` fields
- [x] Verify Loon subscription includes `obfs=salamander,obfs-password=xxx`
- [x] Confirm hy2 connection succeeds on all three clients after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)