### PR TITLE
fix: convert anytls padding_scheme array to string for node compatibility

### DIFF
--- a/app/Services/ServerService.php
+++ b/app/Services/ServerService.php
@@ -211,7 +211,9 @@ class ServerService
                 ...$baseConfig,
                 'server_port' => (int) $serverPort,
                 'server_name' => $protocolSettings['tls']['server_name'],
-                'padding_scheme' => $protocolSettings['padding_scheme'],
+                'padding_scheme' => is_array($protocolSettings['padding_scheme'])
+                    ? implode("\n", $protocolSettings['padding_scheme'])
+                    : ($protocolSettings['padding_scheme'] ?? ''),
             ],
             'socks' => [
                 ...$baseConfig,


### PR DESCRIPTION
## Summary

- `buildNodeConfig()` sends `padding_scheme` as a PHP array, which serializes to a JSON array (`["stop=8","0=30-30",...]`)
- xboard-node (Go) declares `padding_scheme` as `panel.StringOrArray`, but mapstructure cannot decode `[]interface{}` into this custom type
- This causes **all anytls nodes** to fail with: `'padding_scheme' expected type 'panel.StringOrArray', got unconvertible type '[]interface {}'`
- Nodes cannot load config → zero users on anytls

## Fix

Convert the array to a `\n`-delimited string before returning to the node. `StringOrArray` handles plain strings correctly.

```php
// Before
'padding_scheme' => $protocolSettings['padding_scheme'],

// After  
'padding_scheme' => is_array($protocolSettings['padding_scheme'])
    ? implode("\n", $protocolSettings['padding_scheme'])
    : ($protocolSettings['padding_scheme'] ?? ''),
```

## Test plan

- [x] Verified on 39 production nodes — all anytls nodes recovered from zero users
- [x] No `padding_scheme` decode errors in node logs after fix
- [x] Nodes with explicit `padding_scheme` in DB and nodes using the default both work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)