### PR TITLE
fix: protocol bugs in Loon, Stash, and Clash

### DIFF
--- a/app/Protocols/Clash.php
+++ b/app/Protocols/Clash.php
@@ -17,6 +17,9 @@ class Clash extends AbstractProtocol
         Server::TYPE_SHADOWSOCKS,
         Server::TYPE_VMESS,
         Server::TYPE_TROJAN,
+        Server::TYPE_VLESS,
+        Server::TYPE_HYSTERIA,
+        Server::TYPE_ANYTLS,
         Server::TYPE_SOCKS,
         Server::TYPE_HTTP,
     ];
@@ -53,6 +56,18 @@ class Clash extends AbstractProtocol
             }
             if ($item['type'] === Server::TYPE_TROJAN) {
                 array_push($proxy, self::buildTrojan($item['password'], $item));
+                array_push($proxies, $item['name']);
+            }
+            if ($item['type'] === Server::TYPE_VLESS) {
+                array_push($proxy, self::buildVless($item['password'], $item));
+                array_push($proxies, $item['name']);
+            }
+            if ($item['type'] === Server::TYPE_HYSTERIA) {
+                array_push($proxy, self::buildHysteria($item['password'], $item, $user));
+                array_push($proxies, $item['name']);
+            }
+            if ($item['type'] === Server::TYPE_ANYTLS) {
+                array_push($proxy, self::buildAnyTLS($item['password'], $item));
                 array_push($proxies, $item['name']);
             }
             if ($item['type'] === Server::TYPE_SOCKS) {
@@ -262,6 +277,126 @@ class Clash extends AbstractProtocol
                 $array['network'] = 'tcp';
                 break;
         }
+        return $array;
+    }
+
+    public static function buildVless($password, $server)
+    {
+        $protocol_settings = data_get($server, 'protocol_settings', []);
+        $array = [
+            'name' => $server['name'],
+            'type' => 'vless',
+            'server' => $server['host'],
+            'port' => $server['port'],
+            'uuid' => $password,
+            'alterId' => 0,
+            'cipher' => 'auto',
+            'udp' => true,
+            'flow' => data_get($protocol_settings, 'flow'),
+            'tls' => false
+        ];
+
+        switch (data_get($protocol_settings, 'tls')) {
+            case 1:
+                $array['tls'] = true;
+                $array['skip-cert-verify'] = (bool) data_get($protocol_settings, 'tls_settings.allow_insecure', false);
+                if ($serverName = data_get($protocol_settings, 'tls_settings.server_name')) {
+                    $array['servername'] = $serverName;
+                }
+                break;
+            case 2:
+                $array['tls'] = true;
+                $array['skip-cert-verify'] = (bool) data_get($protocol_settings, 'reality_settings.allow_insecure', false);
+                $array['servername'] = data_get($protocol_settings, 'reality_settings.server_name');
+                $array['reality-opts'] = [
+                    'public-key' => data_get($protocol_settings, 'reality_settings.public_key'),
+                    'short-id' => data_get($protocol_settings, 'reality_settings.short_id')
+                ];
+                break;
+            default:
+                break;
+        }
+
+        switch (data_get($protocol_settings, 'network')) {
+            case 'tcp':
+                $array['network'] = 'tcp';
+                break;
+            case 'ws':
+                $array['network'] = 'ws';
+                if ($path = data_get($protocol_settings, 'network_settings.path'))
+                    $array['ws-opts']['path'] = $path;
+                if ($host = data_get($protocol_settings, 'network_settings.headers.Host'))
+                    $array['ws-opts']['headers'] = ['Host' => $host];
+                break;
+            case 'grpc':
+                $array['network'] = 'grpc';
+                if ($serviceName = data_get($protocol_settings, 'network_settings.serviceName'))
+                    $array['grpc-opts']['grpc-service-name'] = $serviceName;
+                break;
+            default:
+                break;
+        }
+
+        return $array;
+    }
+
+    public static function buildHysteria($password, $server, $user)
+    {
+        $protocol_settings = data_get($server, 'protocol_settings', []);
+        $array = [
+            'name' => $server['name'],
+            'server' => $server['host'],
+            'port' => $server['port'],
+            'sni' => data_get($protocol_settings, 'tls.server_name'),
+            'up' => data_get($protocol_settings, 'bandwidth.up'),
+            'down' => data_get($protocol_settings, 'bandwidth.down'),
+            'skip-cert-verify' => (bool) data_get($protocol_settings, 'tls.allow_insecure', false),
+        ];
+        if (isset($server['ports'])) {
+            $array['ports'] = $server['ports'];
+        }
+        switch (data_get($protocol_settings, 'version')) {
+            case 1:
+                $array['type'] = 'hysteria';
+                $array['auth_str'] = $password;
+                $array['protocol'] = 'udp';
+                if (data_get($protocol_settings, 'obfs.open')) {
+                    $array['obfs'] = data_get($protocol_settings, 'obfs.password');
+                }
+                $array['fast-open'] = true;
+                break;
+            case 2:
+                $array['type'] = 'hysteria2';
+                $array['password'] = $password;
+                if (data_get($protocol_settings, 'obfs.open')) {
+                    $array['obfs'] = data_get($protocol_settings, 'obfs.type');
+                    $array['obfs-password'] = data_get($protocol_settings, 'obfs.password');
+                }
+                break;
+        }
+
+        return $array;
+    }
+
+    public static function buildAnyTLS($password, $server)
+    {
+        $protocol_settings = data_get($server, 'protocol_settings', []);
+        $array = [
+            'name' => $server['name'],
+            'type' => 'anytls',
+            'server' => $server['host'],
+            'port' => $server['port'],
+            'password' => $password,
+            'udp' => true,
+        ];
+
+        if ($serverName = data_get($protocol_settings, 'tls.server_name')) {
+            $array['sni'] = $serverName;
+        }
+        if ($allowInsecure = data_get($protocol_settings, 'tls.allow_insecure')) {
+            $array['skip-cert-verify'] = (bool) $allowInsecure;
+        }
+
         return $array;
     }
 

--- a/app/Protocols/Loon.php
+++ b/app/Protocols/Loon.php
@@ -267,7 +267,11 @@ class Loon extends AbstractProtocol
         ];
         if (data_get($protocol_settings, 'tls.allow_insecure'))
             $config[] = "skip-cert-verify=true";
-        $config[] = "download-bandwidth=" . data_get($protocol_settings, 'bandwidth.download_bandwidth');
+        $config[] = "download-bandwidth=" . data_get($protocol_settings, 'bandwidth.down');
+        if (data_get($protocol_settings, 'obfs.open') && data_get($protocol_settings, 'obfs.type') === 'salamander') {
+            $config[] = 'obfs=salamander';
+            $config[] = "obfs-password=" . data_get($protocol_settings, 'obfs.password');
+        }
         $config[] = "udp=true";
         $config = array_filter($config);
         $uri = implode(',', $config);

--- a/app/Protocols/Stash.php
+++ b/app/Protocols/Stash.php
@@ -110,10 +110,10 @@ class Stash extends AbstractProtocol
                 array_push($proxy, self::buildTuic($item['password'], $item));
                 array_push($proxies, $item['name']);
             }
-            // if ($item['type'] === 'anytls') {
-            //     array_push($proxy, self::buildAnyTLS($item['password'], $item));
-            //     array_push($proxies, $item['name']);
-            // }
+            if ($item['type'] === Server::TYPE_ANYTLS) {
+                array_push($proxy, self::buildAnyTLS($item['password'], $item));
+                array_push($proxies, $item['name']);
+            }
             if ($item['type'] === Server::TYPE_SOCKS) {
                 array_push($proxy, self::buildSocks5($item['password'], $item));
                 array_push($proxies, $item['name']);
@@ -404,6 +404,10 @@ class Stash extends AbstractProtocol
                 $array['type'] = 'hysteria2';
                 $array['auth'] = $password;
                 $array['fast-open'] = true;
+                if (data_get($protocol_settings, 'obfs.open')) {
+                    $array['obfs'] = data_get($protocol_settings, 'obfs.type');
+                    $array['obfs-password'] = data_get($protocol_settings, 'obfs.password');
+                }
                 break;
         }
         return $array;
@@ -447,8 +451,8 @@ class Stash extends AbstractProtocol
             'server' => $server['host'],
             'port' => $server['port'],
             'password' => $password,
-            'sni' => data_get($protocol_settings, 'tls_settings.server_name'),
-            'skip-cert-verify' => (bool) data_get($protocol_settings, 'tls_settings.allow_insecure', false),
+            'sni' => data_get($protocol_settings, 'tls.server_name'),
+            'skip-cert-verify' => (bool) data_get($protocol_settings, 'tls.allow_insecure', false),
             'udp' => true,
         ];
 


### PR DESCRIPTION
## Summary

- **Loon.php**: Fix Hysteria2 download bandwidth using wrong field name (`bandwidth.download_bandwidth` → `bandwidth.down`); add missing obfs (salamander) support
- **Stash.php**: Enable AnyTLS support (was commented out); fix AnyTLS TLS field path (`tls_settings.*` → `tls.*`); add missing Hysteria2 obfs support
- **Clash.php**: Add VLESS (TLS/Reality/ws/grpc), Hysteria/Hysteria2 (with obfs), and AnyTLS protocol support — these were already in ClashMeta but missing from the plain Clash protocol handler

## Details

### Loon.php — Hysteria2 bandwidth field name
The XBoard `protocol_settings.bandwidth` object uses `up`/`down` keys (matching ClashMeta, Stash, SingBox), but Loon's `buildHysteria()` was reading `bandwidth.download_bandwidth` which doesn't exist, resulting in empty `download-bandwidth=` in the subscription output.

### Stash.php — AnyTLS commented out + wrong TLS path
1. The AnyTLS handler in `handle()` was fully commented out, so AnyTLS nodes were silently dropped from Stash subscriptions even though `allowedProtocols` included it.
2. `buildAnyTLS()` used `tls_settings.server_name` / `tls_settings.allow_insecure`, but AnyTLS (like Hysteria/TUIC) stores TLS config under `tls.*`, not `tls_settings.*`. This caused SNI and skip-cert-verify to always be null/false.

### Stash.php + Loon.php — Missing Hysteria2 obfs
Neither file handled Hysteria2 obfs (salamander), so nodes with obfs enabled would connect without obfs and fail if the server requires it.

### Clash.php — Missing VLESS/Hysteria/AnyTLS
`allowedProtocols` only listed ss/vmess/trojan/socks/http. Build methods for VLESS, Hysteria, and AnyTLS were missing entirely. Added them following the same patterns used in ClashMeta.php.

## Test plan
- [ ] Verify Loon subscription includes correct `download-bandwidth=` value for Hysteria2 nodes
- [ ] Verify Stash subscription includes AnyTLS nodes with correct SNI
- [ ] Verify Stash Hysteria2 nodes include obfs fields when enabled
- [ ] Verify Clash subscription includes VLESS, Hysteria2, and AnyTLS nodes
- [ ] Verify existing protocols (ss/vmess/trojan/socks/http) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)