### PR TITLE
feat: return online_count in user subscription API

### DIFF
--- a/app/Http/Controllers/V1/User/UserController.php
+++ b/app/Http/Controllers/V1/User/UserController.php
@@ -134,7 +134,8 @@ class UserController extends Controller
                 'uuid',
                 'device_limit',
                 'speed_limit',
-                'next_reset_at'
+                'next_reset_at',
+                'online_count'
             ])
             ->first();
         if (!$user) {


### PR DESCRIPTION
## Summary
- Add `online_count` to the `->select([...])` array in the `getSubscribe()` method of `UserController.php`
- The `online_count` column already exists in the `v2_user` table but was not included in the query, so it was never returned in the subscription API response
- This allows frontends to display the user's current online device count alongside other subscription info (device_limit, transfer usage, etc.)

## Test plan
- [ ] Verify `GET /api/v1/user/getSubscribe` now includes `online_count` in the response
- [ ] Confirm no regression on existing subscription fields
- [ ] Check that frontends consuming this endpoint can render the new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)