### PR TITLE
feat: support shadow-tls in sing-box subscription output

### DIFF
--- a/app/Protocols/SingBox.php
+++ b/app/Protocols/SingBox.php
@@ -96,7 +96,14 @@ class SingBox extends AbstractProtocol
             $protocol_settings = $item['protocol_settings'];
             if ($item['type'] === Server::TYPE_SHADOWSOCKS) {
                 $ssConfig = $this->buildShadowsocks($item['password'], $item);
-                $proxies[] = $ssConfig;
+                if (isset($ssConfig[0]) && is_array($ssConfig[0])) {
+                    // shadow-tls returns [ss_outbound, shadowtls_outbound]
+                    foreach ($ssConfig as $outbound) {
+                        $proxies[] = $outbound;
+                    }
+                } else {
+                    $proxies[] = $ssConfig;
+                }
             }
             if ($item['type'] === Server::TYPE_TROJAN) {
                 $trojanConfig = $this->buildTrojan($this->user['uuid'], $item);
@@ -140,7 +147,7 @@ class SingBox extends AbstractProtocol
         }
         foreach ($outbounds as &$outbound) {
             if (in_array($outbound['type'], ['urltest', 'selector'])) {
-                array_push($outbound['outbounds'], ...array_column($proxies, 'tag'));
+                array_push($outbound['outbounds'], ...array_values(array_filter(array_column($proxies, 'tag'), fn($t) => !str_ends_with($t, '-shadowtls'))));
             }
         }
 
@@ -260,9 +267,44 @@ class SingBox extends AbstractProtocol
         $array['server_port'] = $server['port'];
         $array['method'] = data_get($protocol_settings, 'cipher');
         $array['password'] = data_get($server, 'password', $password);
-        if (data_get($protocol_settings, 'plugin') && data_get($protocol_settings, 'plugin_opts')) {
-            $array['plugin'] = data_get($protocol_settings, 'plugin');
-            $array['plugin_opts'] = data_get($protocol_settings, 'plugin_opts', '');
+
+        $plugin = data_get($protocol_settings, 'plugin');
+        $pluginOpts = data_get($protocol_settings, 'plugin_opts', '');
+
+        if ($plugin === 'shadow-tls' && $pluginOpts) {
+            $parsedOpts = collect(explode(';', $pluginOpts))
+                ->filter()
+                ->mapWithKeys(function ($pair) {
+                    if (!str_contains($pair, '=')) {
+                        return [trim($pair) => true];
+                    }
+                    [$key, $value] = explode('=', $pair, 2);
+                    return [trim($key) => trim($value)];
+                })
+                ->all();
+
+            $stlsTag = $server['name'] . '-shadowtls';
+            $stlsOutbound = [
+                'type' => 'shadowtls',
+                'tag' => $stlsTag,
+                'server' => $server['host'],
+                'server_port' => $server['port'],
+                'version' => (int) ($parsedOpts['version'] ?? 3),
+                'password' => $parsedOpts['password'] ?? '',
+                'tls' => [
+                    'enabled' => true,
+                    'server_name' => $parsedOpts['host'] ?? '',
+                ],
+            ];
+
+            $array['detour'] = $stlsTag;
+
+            return [$array, $stlsOutbound];
+        }
+
+        if ($plugin && $pluginOpts) {
+            $array['plugin'] = $plugin;
+            $array['plugin_opts'] = $pluginOpts;
         }
 
         return $array;


### PR DESCRIPTION
## Problem

When a Shadowsocks node has `plugin: shadow-tls` configured in `protocol_settings`, the sing-box subscription handler passes raw `plugin` / `plugin_opts` strings:

```json
{
  "type": "shadowsocks",
  "plugin": "shadow-tls",
  "plugin_opts": "version=3;host=gateway.icloud.com;password=xxx"
}
```

**sing-box does not support shadow-tls as a plugin field.** This causes shadow-tls nodes to be completely broken for all sing-box-based clients (sing-box, Hiddify, SFM).

Note: Clash Meta (`ClashMeta.php`) already handles this correctly with a dedicated `case 'shadow-tls'` block.

## Fix

Detect `shadow-tls` plugin and generate the proper sing-box outbound chain:

```json
{
  "type": "shadowsocks",
  "tag": "NodeName",
  "detour": "NodeName-shadowtls",
  ...
}
{
  "type": "shadowtls",
  "tag": "NodeName-shadowtls",
  "server": "...",
  "server_port": 443,
  "version": 3,
  "password": "...",
  "tls": { "enabled": true, "server_name": "gateway.icloud.com" }
}
```

The `-shadowtls` helper outbounds are filtered from `selector`/`urltest` proxy groups so they don't appear as standalone nodes.

Other plugins (obfs, v2ray-plugin, etc.) continue to use the existing raw passthrough behavior.

## Test

Verified with sing-box 1.13.x client — shadow-tls nodes now connect successfully via subscription.