### PR TITLE
fix: filter private IPs in device count to prevent false limit violations

### DIFF
--- a/app/Services/UserOnlineService.php
+++ b/app/Services/UserOnlineService.php
@@ -14,6 +14,26 @@ class UserOnlineService
     private const CACHE_PREFIX = 'ALIVE_IP_USER_';
 
     /**
+     * Check if an IP is private/reserved (Docker bridge, loopback, etc.)
+     *
+     * When nodes run behind a TCP proxy (e.g. ShadowTLS) with Docker bridge
+     * networking, the reported source IP is the Docker gateway (172.x.0.1)
+     * instead of the real client IP. Each VPS uses a different bridge subnet,
+     * so these get counted as separate devices, inflating online_count.
+     *
+     * Filters: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8,
+     *          ::1, fc00::/7, and other reserved ranges.
+     */
+    private static function isPrivateIP(string $ip): bool
+    {
+        return filter_var(
+            $ip,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+        ) === false;
+    }
+
+    /**
      * 获取所有限制设备用户的在线数量
      */
     public function getAliveList(Collection $deviceLimitUsers): array
@@ -62,6 +82,7 @@ class UserOnlineService
                     })
                     ->all();
             })
+            ->filter(fn(array $device): bool => !self::isPrivateIP($device['ip']))
             ->values()
             ->all();
 
@@ -98,6 +119,9 @@ class UserOnlineService
 
     /**
      * 计算在线设备数量
+     *
+     * Private/reserved IPs (Docker bridge, loopback, etc.) are excluded
+     * from the count in both modes to prevent false device inflation.
      */
     public static function calculateDeviceCount(array $ipsArray): int
     {
@@ -113,10 +137,15 @@ class UserOnlineService
                         ->all()
                 )
                 ->unique()
+                ->reject(fn(string $ip): bool => self::isPrivateIP($ip))
                 ->count(),
             0 => collect($ipsArray)
                 ->filter(fn(mixed $data): bool => is_array($data) && isset($data['aliveips']))
-                ->sum(fn(array $data): int => count($data['aliveips'])),
+                ->sum(fn(array $data): int => collect($data['aliveips'])
+                    ->map(fn(string $ipNodeId): string => Str::before($ipNodeId, '_'))
+                    ->reject(fn(string $ip): bool => self::isPrivateIP($ip))
+                    ->count()
+                ),
             default => throw new \InvalidArgumentException("Invalid device limit mode: $mode"),
         };
     }


### PR DESCRIPTION
## Problem

When nodes run behind a TCP proxy (e.g. **ShadowTLS**) with Docker bridge networking, the reported source IP is the Docker gateway (`172.x.0.1`) instead of the real client IP. Each VPS uses a different bridge subnet, so these get counted as separate "devices" in `calculateDeviceCount()`.

This causes `online_count` to exceed `device_limit` — especially during **batch speed tests** (e.g. Clash Meta connecting to all nodes simultaneously). A user connecting from 1 real IP to 10 ShadowTLS nodes gets counted as 10+ devices.

**Example from production** (device_limit=5, actual devices=1):
```
shadowsocks217: 172.20.0.1  ← Docker bridge on VPS-1
shadowsocks209: 172.21.0.1  ← Docker bridge on VPS-2
shadowsocks185: 172.23.0.1  ← Docker bridge on VPS-3
shadowsocks205: 172.26.0.1  ← Docker bridge on VPS-4
shadowsocks193: 172.27.0.1  ← Docker bridge on VPS-5
shadowsocks201: 172.28.0.1  ← Docker bridge on VPS-6
anytls9:        101.31.114.194  ← real client IP
→ online_count = 7, exceeds limit of 5
```

## Fix

Add `isPrivateIP()` helper using PHP's `filter_var()` with `FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE` to filter out:
- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC 1918)
- `127.0.0.0/8` (loopback)
- `::1`, `fc00::/7` (IPv6 private)
- Other reserved ranges

Applied in:
- `calculateDeviceCount()` — both mode 0 and mode 1
- `getUserDevices()` — device list display

## Verified

Tested on production with 486 online users. Before fix: multiple users over device_limit. After fix: 0 users over limit.