### PR TITLE
fix: add missing numeric $casts for PostgreSQL compatibility

### DIFF
--- a/app/Models/CommissionLog.php
+++ b/app/Models/CommissionLog.php
@@ -11,6 +11,8 @@ class CommissionLog extends Model
     protected $guarded = ['id'];
     protected $casts = [
         'created_at' => 'timestamp',
-        'updated_at' => 'timestamp'
+        'updated_at' => 'timestamp',
+        'order_amount' => 'integer',
+        'get_amount' => 'integer',
     ];
 }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -50,7 +50,14 @@ class Order extends Model
         'created_at' => 'timestamp',
         'updated_at' => 'timestamp',
         'surplus_order_ids' => 'array',
-        'handling_amount' => 'integer'
+        'total_amount' => 'integer',
+        'handling_amount' => 'integer',
+        'discount_amount' => 'integer',
+        'balance_amount' => 'integer',
+        'refund_amount' => 'integer',
+        'surplus_amount' => 'integer',
+        'commission_balance' => 'integer',
+        'actual_commission_balance' => 'integer',
     ];
 
     const STATUS_PENDING = 0; // 待支付

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -99,6 +99,11 @@ class Plan extends Model
         'prices' => 'array',
         'tags' => 'array',
         'reset_traffic_method' => 'integer',
+        'transfer_enable' => 'integer',
+        'capacity_limit' => 'integer',
+        'speed_limit' => 'integer',
+        'device_limit' => 'integer',
+        'sort' => 'integer',
     ];
 
     /**

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -124,6 +124,9 @@ class Server extends Model
         'updated_at' => 'timestamp',
         'rate_time_ranges' => 'array',
         'rate_time_enable' => 'boolean',
+        'rate' => 'float',
+        'server_port' => 'integer',
+        'sort' => 'integer',
     ];
 
     private const MULTIPLEX_CONFIGURATION = [

--- a/app/Models/Stat.php
+++ b/app/Models/Stat.php
@@ -11,6 +11,9 @@ class Stat extends Model
     protected $guarded = ['id'];
     protected $casts = [
         'created_at' => 'timestamp',
-        'updated_at' => 'timestamp'
+        'updated_at' => 'timestamp',
+        'order_total' => 'integer',
+        'commission_total' => 'integer',
+        'paid_total' => 'integer',
     ];
 }

--- a/app/Models/StatUser.php
+++ b/app/Models/StatUser.php
@@ -23,6 +23,9 @@ class StatUser extends Model
     protected $guarded = ['id'];
     protected $casts = [
         'created_at' => 'timestamp',
-        'updated_at' => 'timestamp'
+        'updated_at' => 'timestamp',
+        'server_rate' => 'float',
+        'u' => 'integer',
+        'd' => 'integer',
     ];
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -77,6 +77,9 @@ class User extends Authenticatable
         'commission_rate' => 'float',
         'next_reset_at' => 'timestamp',
         'last_reset_at' => 'timestamp',
+        'balance' => 'integer',
+        'commission_balance' => 'integer',
+        'discount' => 'integer',
     ];
     protected $hidden = ['password'];
 


### PR DESCRIPTION
## Problem

When using PostgreSQL as the database backend, PHP PDO pgsql driver returns **string** for all non-`int4` numeric column types (`bigint`, `numeric`, `double precision`), unlike MySQL PDO which auto-casts to native PHP types.

Without explicit `$casts` declarations, numeric fields (amounts, balances, rates) are serialized as strings in JSON API responses, causing frontend display issues such as `¥N/A` instead of actual amounts.

### Reproduction

1. Use PostgreSQL backend
2. Create a percentage-based coupon (e.g. 20% off)
3. Place an order — the discounted amount (e.g. `1989 * 0.8 = 1591.2`) may trigger:
   - `SQLSTATE[22P02]: Invalid text representation` if column is `bigint` (PG rejects decimal insertion)
   - After column type fix to `double precision` / `numeric`, amounts display as `N/A` on frontend due to string serialization

## Solution

Add explicit `$casts` to 7 Eloquent models for all numeric fields that need correct PHP typing:

| Model | Fields Added | Cast Type |
|---|---|---|
| `Order` | total_amount, discount_amount, balance_amount, handling_amount, refund_amount, surplus_amount, commission_balance, actual_commission_balance | `integer` |
| `User` | balance, commission_balance, discount | `integer` |
| `CommissionLog` | order_amount, get_amount | `integer` |
| `Stat` | order_total, commission_total, paid_total | `integer` |
| `Plan` | transfer_enable, capacity_limit, speed_limit, device_limit, sort | `integer` |
| `Server` | rate, server_port, sort | `float` / `integer` |
| `StatUser` | server_rate, u, d | `float` / `integer` |

## Backward Compatibility

These casts are **no-ops on MySQL** — MySQL PDO already returns correct native types, so `(int)"1032"` === `1032`. Zero impact on existing MySQL deployments.

## Test

Verified in production with PostgreSQL 15 + PHP 8.2 + Octane (Swoole):
- Order amounts display correctly after fix
- Percentage coupons work without errors
- User balances, commission stats all render properly

🤖 Generated with [Claude Code](https://claude.ai/code)