### PR TITLE
fix: security hardening, bug fixes, and PostgreSQL compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 APP_NAME=XBoard
 APP_ENV=production
-APP_KEY=base64:PZXk5vTuTinfeEVG5FpYv2l6WEhLsyvGpiWK7IgJJ60=
+APP_KEY=
 APP_DEBUG=false
 APP_URL=http://localhost
 

--- a/app/Console/Commands/CheckTrafficExceeded.php
+++ b/app/Console/Commands/CheckTrafficExceeded.php
@@ -26,7 +26,7 @@ class CheckTrafficExceeded extends Command
             ->whereIn('id', $pendingUserIds)
             ->whereRaw('u + d >= transfer_enable')
             ->where('transfer_enable', '>', 0)
-            ->where('banned', 0)
+            ->where('banned', false)
             ->select(['id', 'group_id'])
             ->get();
 

--- a/app/Console/Commands/ResetTraffic.php
+++ b/app/Console/Commands/ResetTraffic.php
@@ -255,7 +255,7 @@ class ResetTraffic extends Command
         $query->where('expired_at', '>', time())
           ->orWhereNull('expired_at');
       })
-      ->where('banned', 0)
+      ->where('banned', false)
       ->whereNotNull('plan_id');
   }
 
@@ -269,7 +269,7 @@ class ResetTraffic extends Command
         $query->where('expired_at', '>', time())
           ->orWhereNull('expired_at');
       })
-      ->where('banned', 0)
+      ->where('banned', false)
       ->with('plan:id,name,reset_traffic_method')
       ->get();
   }
@@ -281,7 +281,7 @@ class ResetTraffic extends Command
         $query->where('expired_at', '>', time())
           ->orWhereNull('expired_at');
       })
-      ->where('banned', 0)
+      ->where('banned', false)
       ->with('plan:id,name,reset_traffic_method')
       ->get();
   }

--- a/app/Http/Controllers/V1/User/KnowledgeController.php
+++ b/app/Http/Controllers/V1/User/KnowledgeController.php
@@ -77,7 +77,7 @@ class KnowledgeController extends Controller
 
     private function buildKnowledgeQuery(array $select = ['*'])
     {
-        return Knowledge::select($select)->where('show', 1);
+        return Knowledge::select($select)->where('show', true);
     }
 
     private function processKnowledgeContent(array $knowledge, User $user): array

--- a/app/Http/Controllers/V1/User/OrderController.php
+++ b/app/Http/Controllers/V1/User/OrderController.php
@@ -182,7 +182,7 @@ class OrderController extends Controller
             'handling_fee_fixed',
             'handling_fee_percent'
         ])
-            ->where('enable', 1)
+            ->where('enable', true)
             ->orderBy('sort', 'ASC')
             ->get();
 

--- a/app/Http/Controllers/V2/Admin/CouponController.php
+++ b/app/Http/Controllers/V2/Admin/CouponController.php
@@ -13,11 +13,13 @@ use Illuminate\Support\Facades\DB;
 
 class CouponController extends Controller
 {
+    use \App\Traits\QueryOperators;
     private function applyFiltersAndSorts(Request $request, $builder)
     {
         if ($request->has('filter')) {
             collect($request->input('filter'))->each(function ($filter) use ($builder) {
                 $key = $filter['id'];
+                if (!$this->isValidFieldName($key)) return;
                 $value = $filter['value'];
                 $builder->where(function ($query) use ($key, $value) {
                     if (is_array($value)) {
@@ -32,6 +34,7 @@ class CouponController extends Controller
         if ($request->has('sort')) {
             collect($request->input('sort'))->each(function ($sort) use ($builder) {
                 $key = $sort['id'];
+                if (!$this->isValidFieldName($key)) return;
                 $value = $sort['desc'] ? 'DESC' : 'ASC';
                 $builder->orderBy($key, $value);
             });

--- a/app/Http/Controllers/V2/Admin/OrderController.php
+++ b/app/Http/Controllers/V2/Admin/OrderController.php
@@ -16,9 +16,11 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Log;
+use App\Traits\QueryOperators;
 
 class OrderController extends Controller
 {
+    use QueryOperators;
 
     public function detail(Request $request)
     {
@@ -77,6 +79,7 @@ class OrderController extends Controller
 
         collect($request->input('filter'))->each(function ($filter) use ($builder) {
             $field = $filter['id'];
+            if (!$this->isValidFieldName($field)) return;
             $value = $filter['value'];
 
             $builder->where(function ($query) use ($field, $value) {
@@ -135,6 +138,7 @@ class OrderController extends Controller
 
         collect($request->input('sort'))->each(function ($sort) use ($builder) {
             $field = $sort['id'];
+            if (!$this->isValidFieldName($field)) return;
             $direction = $sort['desc'] ? 'DESC' : 'ASC';
             $builder->orderBy($field, $direction);
         });

--- a/app/Http/Controllers/V2/Admin/TicketController.php
+++ b/app/Http/Controllers/V2/Admin/TicketController.php
@@ -10,11 +10,13 @@ use Illuminate\Http\Request;
 
 class TicketController extends Controller
 {
+    use \App\Traits\QueryOperators;
     private function applyFiltersAndSorts(Request $request, $builder)
     {
         if ($request->has('filter')) {
             collect($request->input('filter'))->each(function ($filter) use ($builder) {
                 $key = $filter['id'];
+                if (!$this->isValidFieldName($key)) return;
                 $value = $filter['value'];
                 $builder->where(function ($query) use ($key, $value) {
                     if (is_array($value)) {
@@ -29,6 +31,7 @@ class TicketController extends Controller
         if ($request->has('sort')) {
             collect($request->input('sort'))->each(function ($sort) use ($builder) {
                 $key = $sort['id'];
+                if (!$this->isValidFieldName($key)) return;
                 $value = $sort['desc'] ? 'DESC' : 'ASC';
                 $builder->orderBy($key, $value);
             });

--- a/app/Http/Controllers/V2/Admin/UserController.php
+++ b/app/Http/Controllers/V2/Admin/UserController.php
@@ -52,6 +52,7 @@ class UserController extends Controller
 
         collect($request->input('filter'))->each(function ($filter) use ($builder) {
             $field = $filter['id'];
+            if (!$this->isValidFieldName($field)) return;
             $value = $filter['value'];
             $logic = strtolower($filter['logic'] ?? 'and');
 
@@ -128,6 +129,7 @@ class UserController extends Controller
 
         collect($request->input('sort'))->each(function ($sort) use ($builder) {
             $field = $sort['id'];
+            if (!$this->isValidFieldName($field)) return;
             $direction = $sort['desc'] ? 'DESC' : 'ASC';
             $builder->orderBy($field, $direction);
         });

--- a/app/Http/Middleware/Server.php
+++ b/app/Http/Middleware/Server.php
@@ -35,7 +35,7 @@ class Server
                 'string',
                 'required',
                 function ($attribute, $value, $fail) {
-                    if ($value !== admin_setting('server_token')) {
+                    if (!hash_equals((string) admin_setting('server_token'), (string) $value)) {
                         $fail("Invalid {$attribute}");
                     }
                 },

--- a/app/Observers/PlanObserver.php
+++ b/app/Observers/PlanObserver.php
@@ -18,7 +18,7 @@ class PlanObserver
         }
         $trafficResetService = app(TrafficResetService::class);
         User::where('plan_id', $plan->id)
-            ->where('banned', 0)
+            ->where('banned', false)
             ->where(function ($query) {
                 $query->where('expired_at', '>', time())
                     ->orWhereNull('expired_at');

--- a/app/Observers/ServerRouteObserver.php
+++ b/app/Observers/ServerRouteObserver.php
@@ -20,7 +20,7 @@ class ServerRouteObserver
 
     private function notifyAffectedNodes(int $routeId): void
     {
-        $servers = Server::where('show', 1)->get()->filter(
+        $servers = Server::where('show', true)->get()->filter(
             fn ($s) => in_array($routeId, $s->route_ids ?? [])
         );
 

--- a/app/Services/CouponService.php
+++ b/app/Services/CouponService.php
@@ -16,37 +16,43 @@ class CouponService
 
     public function __construct($code)
     {
-        $this->coupon = Coupon::where('code', $code)
-            ->lockForUpdate()
-            ->first();
+        $this->coupon = Coupon::where('code', $code)->first();
     }
 
     public function use(Order $order): bool
     {
-        $this->setPlanId($order->plan_id);
-        $this->setUserId($order->user_id);
-        $this->setPeriod($order->period);
-        $this->check();
-        switch ($this->coupon->type) {
-            case 1:
-                $order->discount_amount = $this->coupon->value;
-                break;
-            case 2:
-                $order->discount_amount = $order->total_amount * ($this->coupon->value / 100);
-                break;
-        }
-        if ($order->discount_amount > $order->total_amount) {
-            $order->discount_amount = $order->total_amount;
-        }
-        if ($this->coupon->limit_use !== NULL) {
-            if ($this->coupon->limit_use <= 0)
-                return false;
-            $this->coupon->limit_use = $this->coupon->limit_use - 1;
-            if (!$this->coupon->save()) {
-                return false;
+        return DB::transaction(function () use ($order) {
+            // Re-fetch with lock inside transaction to prevent race conditions
+            $this->coupon = Coupon::where('id', $this->coupon->id)
+                ->lockForUpdate()
+                ->first();
+            if (!$this->coupon) return false;
+
+            $this->setPlanId($order->plan_id);
+            $this->setUserId($order->user_id);
+            $this->setPeriod($order->period);
+            $this->check();
+            switch ($this->coupon->type) {
+                case 1:
+                    $order->discount_amount = $this->coupon->value;
+                    break;
+                case 2:
+                    $order->discount_amount = $order->total_amount * ($this->coupon->value / 100);
+                    break;
             }
-        }
-        return true;
+            if ($order->discount_amount > $order->total_amount) {
+                $order->discount_amount = $order->total_amount;
+            }
+            if ($this->coupon->limit_use !== NULL) {
+                if ($this->coupon->limit_use <= 0)
+                    return false;
+                $this->coupon->limit_use = $this->coupon->limit_use - 1;
+                if (!$this->coupon->save()) {
+                    return false;
+                }
+            }
+            return true;
+        });
     }
 
     public function getId()

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -132,7 +132,7 @@ class OrderService
         });
 
         $eventId = match ((int) $order->type) {
-            Order::STATUS_PROCESSING => admin_setting('new_order_event_id', 0),
+            Order::TYPE_NEW_PURCHASE => admin_setting('new_order_event_id', 0),
             Order::TYPE_RENEWAL => admin_setting('renew_order_event_id', 0),
             Order::TYPE_UPGRADE => admin_setting('change_order_event_id', 0),
             default => 0,

--- a/app/Services/ServerService.php
+++ b/app/Services/ServerService.php
@@ -82,7 +82,7 @@ class ServerService
                 $query->where('expired_at', '>=', time())
                     ->orWhere('expired_at', NULL);
             })
-            ->where('banned', 0)
+            ->where('banned', false)
             ->select([
                 'id',
                 'uuid',

--- a/app/Services/TelegramService.php
+++ b/app/Services/TelegramService.php
@@ -116,8 +116,8 @@ class TelegramService
     {
         $query = User::where('telegram_id', '!=', null);
         $query->where(
-            fn($q) => $q->where('is_admin', 1)
-                ->when($isStaff, fn($q) => $q->orWhere('is_staff', 1))
+            fn($q) => $q->where('is_admin', true)
+                ->when($isStaff, fn($q) => $q->orWhere('is_staff', true))
         );
         $users = $query->get();
         foreach ($users as $user) {

--- a/app/Services/ThemeService.php
+++ b/app/Services/ThemeService.php
@@ -118,6 +118,15 @@ class ThemeService
                 throw new Exception('Theme config file not found');
             }
 
+            // Validate zip entries against ZipSlip (path traversal)
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $entryName = $zip->getNameIndex($i);
+                $fullPath = realpath($tmpPath) ? realpath($tmpPath) . '/' . $entryName : $tmpPath . '/' . $entryName;
+                if (str_contains($entryName, '..')) {
+                    $zip->close();
+                    throw new Exception('Invalid file path detected in theme package');
+                }
+            }
             $zip->extractTo($tmpPath);
             $zip->close();
 

--- a/app/Services/TrafficResetService.php
+++ b/app/Services/TrafficResetService.php
@@ -273,7 +273,7 @@ class TrafficResetService
             $query->where('expired_at', '>', time())
               ->orWhereNull('expired_at');
           })
-          ->where('banned', 0)
+          ->where('banned', false)
           ->whereNotNull('plan_id')
           ->orderBy('id')
           ->limit($batchSize)

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -10,6 +10,7 @@ use App\Models\Plan;
 use App\Models\Server;
 use App\Models\User;
 use App\Services\Plugin\HookManager;
+use Illuminate\Support\Facades\DB;
 use App\Services\TrafficResetService;
 use App\Models\TrafficResetLog;
 use App\Utils\Helper;
@@ -58,9 +59,9 @@ class UserService
         return User::whereRaw('u + d < transfer_enable')
             ->where(function ($query) {
                 $query->where('expired_at', '>=', time())
-                    ->orWhere('expired_at', NULL);
+                    ->orWhereNull('expired_at');
             })
-            ->where('banned', 0)
+            ->where('banned', false)
             ->get();
     }
 
@@ -71,7 +72,7 @@ class UserService
                 ->orWhere('expired_at', 0);
         })
             ->where(function ($query) {
-                $query->where('plan_id', NULL)
+                $query->whereNull('plan_id')
                     ->orWhere('transfer_enable', 0);
             })
             ->get();
@@ -89,18 +90,20 @@ class UserService
 
     public function addBalance(int $userId, int $balance): bool
     {
-        $user = User::lockForUpdate()->find($userId);
-        if (!$user) {
-            return false;
-        }
-        $user->balance = $user->balance + $balance;
-        if ($user->balance < 0) {
-            return false;
-        }
-        if (!$user->save()) {
-            return false;
-        }
-        return true;
+        return DB::transaction(function () use ($userId, $balance) {
+            $user = User::lockForUpdate()->find($userId);
+            if (!$user) {
+                return false;
+            }
+            $user->balance = $user->balance + $balance;
+            if ($user->balance < 0) {
+                return false;
+            }
+            if (!$user->save()) {
+                return false;
+            }
+            return true;
+        });
     }
 
     public function isNotCompleteOrderByUserId(int $userId): bool

--- a/app/Traits/QueryOperators.php
+++ b/app/Traits/QueryOperators.php
@@ -7,6 +7,15 @@ use Illuminate\Contracts\Database\Query\Expression;
 trait QueryOperators
 {
     /**
+     * Validate that a field name is safe for use in queries.
+     * Prevents SQL injection via user-controlled column names.
+     */
+    protected function isValidFieldName(string $field): bool
+    {
+        return (bool) preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)?$/', $field);
+    }
+
+    /**
      * 获取查询运算符映射
      *
      * @param string $operator

--- a/database/migrations/2025_01_15_000002_add_stat_performance_indexes.php
+++ b/database/migrations/2025_01_15_000002_add_stat_performance_indexes.php
@@ -6,45 +6,57 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {
     /**
+     * Safely add an index only if it doesn't already exist.
+     */
+    private function addIndexIfNotExists(Blueprint $table, string $column): void
+    {
+        $tableName = $table->getTable();
+        $indexName = "{$tableName}_{$column}_index";
+        if (!Schema::hasIndex($tableName, $indexName)) {
+            $table->index($column);
+        }
+    }
+
+    /**
      * Run the migrations.
      */
     public function up(): void
     {
         Schema::table('v2_user', function (Blueprint $table) {
-            $table->index('t');
-            $table->index('online_count');
-            $table->index('created_at');
+            $this->addIndexIfNotExists($table, 't');
+            $this->addIndexIfNotExists($table, 'online_count');
+            $this->addIndexIfNotExists($table, 'created_at');
         });
 
         Schema::table('v2_order', function (Blueprint $table) {
-            $table->index('created_at');
-            $table->index('status');
-            $table->index('total_amount');
-            $table->index('commission_status');
-            $table->index('invite_user_id');
-            $table->index('commission_balance');
+            $this->addIndexIfNotExists($table, 'created_at');
+            $this->addIndexIfNotExists($table, 'status');
+            $this->addIndexIfNotExists($table, 'total_amount');
+            $this->addIndexIfNotExists($table, 'commission_status');
+            $this->addIndexIfNotExists($table, 'invite_user_id');
+            $this->addIndexIfNotExists($table, 'commission_balance');
         });
 
         Schema::table('v2_stat_server', function (Blueprint $table) {
-            $table->index('server_id');
-            $table->index('record_at');
-            $table->index('u');
-            $table->index('d');
+            $this->addIndexIfNotExists($table, 'server_id');
+            $this->addIndexIfNotExists($table, 'record_at');
+            $this->addIndexIfNotExists($table, 'u');
+            $this->addIndexIfNotExists($table, 'd');
         });
 
         Schema::table('v2_stat_user', function (Blueprint $table) {
-            $table->index('u');
-            $table->index('d');
+            $this->addIndexIfNotExists($table, 'u');
+            $this->addIndexIfNotExists($table, 'd');
         });
 
         Schema::table('v2_commission_log', function (Blueprint $table) {
-            $table->index('created_at');
-            $table->index('get_amount');
+            $this->addIndexIfNotExists($table, 'created_at');
+            $this->addIndexIfNotExists($table, 'get_amount');
         });
 
         Schema::table('v2_ticket', function (Blueprint $table) {
-            $table->index('status');
-            $table->index('created_at');
+            $this->addIndexIfNotExists($table, 'status');
+            $this->addIndexIfNotExists($table, 'created_at');
         });
     }
 


### PR DESCRIPTION
## Summary

A batch of security, correctness, and PostgreSQL compatibility fixes found during code audit.

### Security Fixes

**1. SQL injection via admin filter/sort field names**
Admin table endpoints (`UserController`, `OrderController`, `CouponController`, `TicketController`) accept user-controlled `filter[].id` / `sort[].id` as column names. `orderBy()` column names are NOT parameterized by Laravel — an attacker with admin access could inject SQL expressions. Added `isValidFieldName()` regex validation (`/^[a-zA-Z_][a-zA-Z0-9_.]*$/`) to `QueryOperators` trait.

**2. ZipSlip in theme upload** (`ThemeService.php`)
`$zip->extractTo()` without validating entry paths allows path traversal via filenames like `../../etc/cron.d/evil`. Added `..` detection before extraction.

**3. Timing-safe token comparison** (`Middleware/Server.php`)
Changed `$value !== admin_setting('server_token')` to `hash_equals()` to prevent timing attacks on the server communication token.

**4. Hardcoded APP_KEY in `.env.example`**
Removed the pre-set `APP_KEY` value. Deployments that skip `php artisan key:generate` would share a known encryption key.

### Bug Fixes

**5. Wrong constant in order event dispatch** (`OrderService.php:134`)
```php
// Before: uses STATUS_PROCESSING (status constant) to match order TYPE
Order::STATUS_PROCESSING => admin_setting('new_order_event_id', 0),
// After: correct constant
Order::TYPE_NEW_PURCHASE => admin_setting('new_order_event_id', 0),
```
Both constants happen to equal `1`, so no behavioral change — but semantically wrong and fragile.

**6. `where('plan_id', NULL)` never matches** (`UserService.php`)
SQL `WHERE plan_id = NULL` is always false — must use `IS NULL`. Changed to `whereNull('plan_id')`. Same fix for `expired_at`.

**7. Coupon race condition** (`CouponService.php`)
`lockForUpdate()` was called in the constructor (outside any transaction), so the lock was immediately released. Two concurrent requests could both read `limit_use = 1`, both succeed, and over-consume the coupon. Moved the lock inside a `DB::transaction()` in the `use()` method.

**8. Balance race condition** (`UserService::addBalance()`)
Same pattern — `lockForUpdate()` without a wrapping transaction. Wrapped in `DB::transaction()`.

**9. Duplicate index migration fails** (`2025_01_15_000002`)
`v2_stat_server.server_id` and `record_at` indexes already exist from the initial migration. Running this migration on an existing database throws "duplicate index" errors. Added `Schema::hasIndex()` check before each `$table->index()`.

### PostgreSQL Compatibility

**10. Boolean column comparisons** (8 files)
PostgreSQL boolean columns reject integer comparisons (`WHERE banned = 0` → error). Changed all `where('banned', 0)` to `where('banned', false)` and `where('show', 1)` to `where('show', true)`. These changes are backward-compatible with MySQL.

## Files Changed (20 files, +124 -73)

| Category | Files |
|----------|-------|
| Security | `QueryOperators.php`, `UserController`, `OrderController`, `CouponController`, `TicketController`, `Server.php` middleware, `ThemeService.php`, `.env.example` |
| Bug fixes | `OrderService.php`, `UserService.php`, `CouponService.php`, migration file |
| PG compat | `KnowledgeController`, `OrderController`, `CheckTrafficExceeded`, `ResetTraffic`, `PlanObserver`, `ServerRouteObserver`, `ServerService`, `TrafficResetService` |

## Test Plan

- [x] All boolean fixes verified on production PostgreSQL deployment
- [x] Field name validation regex tested — allows `column_name`, `relation.column`, rejects `; DROP TABLE`, `column--`, `1 OR 1=1`
- [ ] MySQL deployments unaffected (boolean `true`/`false` works on MySQL)
- [ ] Coupon concurrent usage should now be properly serialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)