### PR TITLE
fix: handle missing sign parameter in EPay notify callback

### DIFF
--- a/plugins/Epay/Plugin.php
+++ b/plugins/Epay/Plugin.php
@@ -79,7 +79,8 @@ class Plugin extends AbstractPlugin implements PaymentInterface
 
     public function notify($params): array|bool
     {
-        $sign = $params['sign'];
+        $sign = $params['sign'] ?? null;
+        if (!$sign) return false;
         unset($params['sign'], $params['sign_type']);
         ksort($params);
         $str = stripslashes(urldecode(http_build_query($params))) . $this->getConfig('key');


### PR DESCRIPTION
## Summary

- PHP 8 throws `ErrorException: Undefined array key "sign"` when accessing `$params['sign']` on an empty/incomplete POST body
- When the payment callback POST body is lost through CDN/proxy layers (e.g., Cloudflare forwarding, reverse proxy misconfiguration), `$request->input()` returns an empty array
- This causes a 500 error response, and the payment gateway interprets it as a failure and retries indefinitely
- **Fix**: use null coalescing operator (`??`) and return `false` early to gracefully reject invalid callbacks

## Changes

`plugins/Epay/Plugin.php` line 82:

```php
// Before
$sign = $params['sign'];

// After
$sign = $params['sign'] ?? null;
if (!$sign) return false;
```

## Test plan

- [ ] Verify normal EPay payment callback still works (sign present and valid)
- [ ] Verify callback with empty POST body returns `false` instead of 500
- [ ] Verify callback with missing `sign` key returns `false` instead of throwing exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)