### PR TITLE
Update ClashMeta.php

### DIFF
--- a/app/Protocols/ClashMeta.php
+++ b/app/Protocols/ClashMeta.php
@@ -141,7 +141,7 @@ class ClashMeta extends AbstractProtocol
             return $group['proxies'];
         });
         $config['proxy-groups'] = array_values($config['proxy-groups']);
-        $config = $this->buildRules($config);
+        $config = $this->buildRules($config,$user);
 
         $yaml = Yaml::dump($config, 2, 4, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
         $yaml = str_replace('$app_name', admin_setting('app_name', 'XBoard'), $yaml);
@@ -155,10 +155,11 @@ class ClashMeta extends AbstractProtocol
     /**
      * Build the rules for Clash.
      */
-    public function buildRules($config)
+    public function buildRules($config,$user)
     {
         // Force the current subscription domain to be a direct rule
-        $subsDomain = request()->header('Host');
+        $subsURL = Helper::getSubscribeUrl($user['token']);
+        $subsDomain = parse_url($subsURL, PHP_URL_HOST);            
         if ($subsDomain) {
             array_unshift($config['rules'], "DOMAIN,{$subsDomain},DIRECT");
         }


### PR DESCRIPTION
clash配置文件中第一行规则让订阅走直连，获取订阅的方式不对，目前是会获取到后台的域名。不太安全，改为直接获取后台设置的订阅域名