### PR TITLE
fix(admin): expose is_me on ticket messages so admin panel renders right/left split

### DIFF
--- a/app/Http/Controllers/V2/Admin/TicketController.php
+++ b/app/Http/Controllers/V2/Admin/TicketController.php
@@ -56,6 +56,16 @@ class TicketController extends Controller
             return $this->fail([400202, '工单不存在']);
         }
         $result = $ticket->toArray();
+        // Backwards-compat: admin frontend bundle still reads `is_me` on each
+        // message, but the model now exposes `is_from_user` / `is_from_admin`
+        // via $appends. Without this mapping every message renders left-aligned
+        // (received) in the admin panel ticket view.
+        if (isset($result['messages']) && is_array($result['messages'])) {
+            foreach ($result['messages'] as &$message) {
+                $message['is_me'] = !empty($message['is_from_admin']);
+            }
+            unset($message);
+        }
         $result['user'] = UserController::transformUserData($ticket->user);
 
         return $this->success($result);


### PR DESCRIPTION
## Bug

In the admin panel ticket conversation view (`/admin/ticket/<id>`), every message — both the original user post and admin replies — renders left-aligned (`mr-auto`, variant `received`). What should look like a two-sided chat looks like a single-column log.

## Root cause

The prebuilt admin panel JS bundle still reads `e.is_me` when rendering each message:

```js
variant: e.is_me ? "sent" : "received",
className: e.is_me ? "ml-auto" : "mr-auto"
```

But the `TicketMessage` model exposes `is_from_user` and `is_from_admin` (via `$appends`) instead of `is_me`. The admin endpoint `Admin\TicketController::fetchTicketById` returns `$ticket->toArray()` directly, so the response has `is_from_user` / `is_from_admin` but no `is_me` — the bundle's check is always `undefined → falsy`, so every message falls into the "received" branch.

Verified on a fresh `cedar2025/xboard:latest`:

```
$ grep -c is_me        public/assets/admin/assets/index-*.js   → 1
$ grep -c is_from_admin public/assets/admin/assets/index-*.js  → 0
$ grep -c is_from_user  public/assets/admin/assets/index-*.js  → 0
```

User-facing `V1/User/TicketController` is unaffected because its `MessageResource` already maps `is_me` explicitly.

## Fix

Map `is_me = is_from_admin` on each message in `fetchTicketById` (admin's perspective: "me" = admin reply). Keeps the existing admin bundle working without a frontend rebuild.

```php
foreach ($result['messages'] as &$message) {
    $message['is_me'] = !empty($message['is_from_admin']);
}
```

10-line change, no behavior change for callers that already use `is_from_user` / `is_from_admin`.

## Repro

1. As an admin, reply to any open ticket.
2. Open `/admin/ticket/<id>` in the panel.
3. Observe both the user's original message and the admin reply rendered on the left side.
4. Hit `/api/v2/admin/ticket/fetch?id=<id>` and inspect `data.messages[*]` — note `is_me` is missing.

## Test plan

- [x] PHP lint passes (`php -l`)
- [x] API response now contains `is_me` on each message
- [x] Verified in production (admin reply shows `is_me=true`, user message `is_me=false`)
- [ ] Visual check in admin panel — admin sees right/left split