### PR TITLE
fix(pg): use whereLike for case-insensitive admin search (cross-DB)

### DIFF
--- a/app/Http/Controllers/V2/Admin/CouponController.php
+++ b/app/Http/Controllers/V2/Admin/CouponController.php
@@ -23,7 +23,7 @@ class CouponController extends Controller
                     if (is_array($value)) {
                         $query->whereIn($key, $value);
                     } else {
-                        $query->where($key, 'like', "%{$value}%");
+                        $query->whereLike($key, "%{$value}%", false);
                     }
                 });
             });

--- a/app/Http/Controllers/V2/Admin/OrderController.php
+++ b/app/Http/Controllers/V2/Admin/OrderController.php
@@ -95,7 +95,7 @@ class OrderController extends Controller
 
         // Handle operator-based filtering
         if (!is_string($value) || !str_contains($value, ':')) {
-            $query->where($field, 'like', "%{$value}%");
+            $query->whereLike($field, "%{$value}%", false);
             return;
         }
 
@@ -108,23 +108,28 @@ class OrderController extends Controller
                 : (int) $filterValue;
         }
 
-        // Apply operator
-        $query->where($field, match (strtolower($operator)) {
+        // Apply operator (use whereLike so PG gets ILIKE automatically)
+        $op = strtolower($operator);
+        if (in_array($op, ['like', 'notlike'], true) || !in_array($op, ['eq','gt','gte','lt','lte','null','notnull'], true)) {
+            $method = $op === 'notlike' ? 'whereNotLike' : 'whereLike';
+            $query->{$method}($field, "%{$filterValue}%", false);
+            return;
+        }
+        if ($op === 'null') {
+            $query->whereNull($field);
+            return;
+        }
+        if ($op === 'notnull') {
+            $query->whereNotNull($field);
+            return;
+        }
+        $query->where($field, match ($op) {
             'eq' => '=',
             'gt' => '>',
             'gte' => '>=',
             'lt' => '<',
             'lte' => '<=',
-            'like' => 'like',
-            'notlike' => 'not like',
-            'null' => static fn($q) => $q->whereNull($field),
-            'notnull' => static fn($q) => $q->whereNotNull($field),
-            default => 'like'
-        }, match (strtolower($operator)) {
-            'like', 'notlike' => "%{$filterValue}%",
-            'null', 'notnull' => null,
-            default => $filterValue
-        });
+        }, $filterValue);
     }
 
     private function applySorting(Request $request, Builder $builder): void

--- a/app/Http/Controllers/V2/Admin/SystemController.php
+++ b/app/Http/Controllers/V2/Admin/SystemController.php
@@ -109,8 +109,8 @@ class SystemController extends Controller
             ->when($request->input('admin_id'), fn($q, $v) => $q->where('admin_id', $v))
             ->when($request->input('keyword'), function ($q, $keyword) {
                 $q->where(function ($q) use ($keyword) {
-                    $q->where('uri', 'like', '%' . $keyword . '%')
-                      ->orWhere('request_data', 'like', '%' . $keyword . '%');
+                    $q->whereLike('uri', '%' . $keyword . '%', false)
+                      ->orWhereLike('request_data', '%' . $keyword . '%', false);
                 });
             });
 

--- a/app/Http/Controllers/V2/Admin/TicketController.php
+++ b/app/Http/Controllers/V2/Admin/TicketController.php
@@ -20,7 +20,7 @@ class TicketController extends Controller
                     if (is_array($value)) {
                         $query->whereIn($key, $value);
                     } else {
-                        $query->where($key, 'like', "%{$value}%");
+                        $query->whereLike($key, "%{$value}%", false);
                     }
                 });
             });

--- a/app/Http/Controllers/V2/Admin/TrafficResetController.php
+++ b/app/Http/Controllers/V2/Admin/TrafficResetController.php
@@ -47,7 +47,7 @@ class TrafficResetController extends Controller
 
     if ($request->filled('user_email')) {
       $query->whereHas('user', function ($query) use ($request) {
-        $query->where('email', 'like', '%' . $request->user_email . '%');
+        $query->whereLike('email', '%' . $request->user_email . '%', false);
       });
     }
 

--- a/app/Http/Controllers/V2/Admin/UserController.php
+++ b/app/Http/Controllers/V2/Admin/UserController.php
@@ -83,7 +83,7 @@ class UserController extends Controller
                     [$operator, $filterValue] = explode(':', $value, 2);
                     $this->applyQueryCondition($q, $relationField, $operator, $filterValue);
                 } else {
-                    $q->where($relationField, 'like', "%{$value}%");
+                    $q->whereLike($relationField, "%{$value}%", false);
                 }
             });
             return;
@@ -97,7 +97,7 @@ class UserController extends Controller
 
         // 处理基于运算符的过滤
         if (!is_string($value) || !str_contains($value, ':')) {
-            $query->where($field, 'like', "%{$value}%");
+            $query->whereLike($field, "%{$value}%", false);
             return;
         }
 

--- a/app/Scope/FilterScope.php
+++ b/app/Scope/FilterScope.php
@@ -40,7 +40,7 @@ trait FilterScope
                     continue;
                 }
                 if ($filter['condition'] === 'like') {
-                    $builder->where($filter['key'], 'like', "%{$filter['value']}%");
+                    $builder->whereLike($filter['key'], "%{$filter['value']}%", false);
                     continue;
                 }
             }

--- a/app/Traits/QueryOperators.php
+++ b/app/Traits/QueryOperators.php
@@ -56,11 +56,16 @@ trait QueryOperators
     protected function applyQueryCondition($query, array|Expression|string $field, string $operator, mixed $value): void
     {
         $queryOperator = $this->getQueryOperator($operator);
-        
+
         if ($queryOperator === 'null') {
             $query->whereNull($field);
         } elseif ($queryOperator === 'notnull') {
             $query->whereNotNull($field);
+        } elseif ($queryOperator === 'like') {
+            // Cross-DB case-insensitive LIKE: PG → ILIKE, MySQL → LIKE (ci collation)
+            $query->whereLike($field, $this->formatQueryValue($operator, $value), false);
+        } elseif ($queryOperator === 'not like') {
+            $query->whereNotLike($field, $this->formatQueryValue($operator, $value), false);
         } else {
             $query->where($field, $queryOperator, $this->formatQueryValue($operator, $value));
         }


### PR DESCRIPTION
## Summary

PostgreSQL's `LIKE` is **case-sensitive**; MySQL's `LIKE` follows column collation (case-insensitive by default). Admin search filters across the codebase use `->where(\$col, 'like', '%\$v%')`, so on PG, searching `\"foo\"` will not match `\"FOO@example.com\"`. UX diverges between the two DB backends.

Laravel 11+ provides `whereLike(\$col, \$pattern, \$caseSensitive = false)` which emits the correct dialect-specific SQL automatically:

| DB | SQL emitted |
|---|---|
| MySQL | `col LIKE ?` |
| PG | `col ILIKE ?` |
| SQLite | `col LIKE ? ESCAPE '\'` (case-insensitive for ASCII) |

## Changes

**Central dispatch** — one trait fix covers 4 admin controllers that already use `QueryOperators`:

- `app/Traits/QueryOperators.php` — route `'like'`/`'not like'` through `whereLike`/`whereNotLike` in `applyQueryCondition()`.

**Direct call sites** switched from `->where(\$col, 'like', \$v)` to `->whereLike(\$col, \$v, false)`:

- `app/Scope/FilterScope.php`
- `app/Http/Controllers/V2/Admin/TrafficResetController.php` (user_email search)
- `app/Http/Controllers/V2/Admin/SystemController.php` (audit log keyword search)
- `app/Http/Controllers/V2/Admin/UserController.php` (relation field + main filter)
- `app/Http/Controllers/V2/Admin/OrderController.php` (inline match with 'like' branch — refactored to explicit dispatch)
- `app/Http/Controllers/V2/Admin/CouponController.php`
- `app/Http/Controllers/V2/Admin/TicketController.php`

**+32 / −22** across 8 files.

## Compatibility

- **MySQL** — no behavior change; `whereLike(\$col, \$v, false)` emits `LIKE ?` under default ci collation, matching prior code.
- **PG** — now emits `ILIKE ?`, aligning with MySQL's case-insensitive UX.
- **SQLite** — `LIKE` is case-insensitive for ASCII by default; `whereLike` emits `LIKE ? ESCAPE '\'` which is identical for search patterns.

## Test plan

- [x] \`php -l\` all 8 files
- [x] PG 17 + Laravel 12 production: admin user search \"FOO\" now matches \"foo@example.com\" (was empty before)
- [x] MySQL 8 smoke regression — same result sets as before
- [x] No new dependencies; Laravel 11.7+ shipped \`whereLike\` (current composer.json requires ^12.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)