### PR TITLE
fix(security): validate user-controlled field names in admin filter/sort

### DIFF
--- a/app/Http/Controllers/V2/Admin/CouponController.php
+++ b/app/Http/Controllers/V2/Admin/CouponController.php
@@ -7,17 +7,21 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\CouponGenerate;
 use App\Http\Requests\Admin\CouponSave;
 use App\Models\Coupon;
+use App\Traits\QueryOperators;
 use App\Utils\Helper;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class CouponController extends Controller
 {
+    use QueryOperators;
+
     private function applyFiltersAndSorts(Request $request, $builder)
     {
         if ($request->has('filter')) {
             collect($request->input('filter'))->each(function ($filter) use ($builder) {
                 $key = $filter['id'];
+                if (!$this->isValidFieldName($key)) return;
                 $value = $filter['value'];
                 $builder->where(function ($query) use ($key, $value) {
                     if (is_array($value)) {
@@ -32,6 +36,7 @@ class CouponController extends Controller
         if ($request->has('sort')) {
             collect($request->input('sort'))->each(function ($sort) use ($builder) {
                 $key = $sort['id'];
+                if (!$this->isValidFieldName($key)) return;
                 $value = $sort['desc'] ? 'DESC' : 'ASC';
                 $builder->orderBy($key, $value);
             });

--- a/app/Http/Controllers/V2/Admin/OrderController.php
+++ b/app/Http/Controllers/V2/Admin/OrderController.php
@@ -11,6 +11,7 @@ use App\Models\User;
 use App\Services\OrderService;
 use App\Services\PlanService;
 use App\Services\UserService;
+use App\Traits\QueryOperators;
 use App\Utils\Helper;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -19,6 +20,8 @@ use Illuminate\Support\Facades\Log;
 
 class OrderController extends Controller
 {
+    use QueryOperators;
+
 
     public function detail(Request $request)
     {
@@ -77,6 +80,7 @@ class OrderController extends Controller
 
         collect($request->input('filter'))->each(function ($filter) use ($builder) {
             $field = $filter['id'];
+            if (!$this->isValidFieldName($field)) return;
             $value = $filter['value'];
 
             $builder->where(function ($query) use ($field, $value) {
@@ -135,6 +139,7 @@ class OrderController extends Controller
 
         collect($request->input('sort'))->each(function ($sort) use ($builder) {
             $field = $sort['id'];
+            if (!$this->isValidFieldName($field)) return;
             $direction = $sort['desc'] ? 'DESC' : 'ASC';
             $builder->orderBy($field, $direction);
         });

--- a/app/Http/Controllers/V2/Admin/TicketController.php
+++ b/app/Http/Controllers/V2/Admin/TicketController.php
@@ -5,16 +5,20 @@ namespace App\Http\Controllers\V2\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Ticket;
 use App\Services\TicketService;
+use App\Traits\QueryOperators;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 
 class TicketController extends Controller
 {
+    use QueryOperators;
+
     private function applyFiltersAndSorts(Request $request, $builder)
     {
         if ($request->has('filter')) {
             collect($request->input('filter'))->each(function ($filter) use ($builder) {
                 $key = $filter['id'];
+                if (!$this->isValidFieldName($key)) return;
                 $value = $filter['value'];
                 $builder->where(function ($query) use ($key, $value) {
                     if (is_array($value)) {
@@ -29,6 +33,7 @@ class TicketController extends Controller
         if ($request->has('sort')) {
             collect($request->input('sort'))->each(function ($sort) use ($builder) {
                 $key = $sort['id'];
+                if (!$this->isValidFieldName($key)) return;
                 $value = $sort['desc'] ? 'DESC' : 'ASC';
                 $builder->orderBy($key, $value);
             });

--- a/app/Http/Controllers/V2/Admin/UserController.php
+++ b/app/Http/Controllers/V2/Admin/UserController.php
@@ -52,6 +52,7 @@ class UserController extends Controller
 
         collect($request->input('filter'))->each(function ($filter) use ($builder) {
             $field = $filter['id'];
+            if (!$this->isValidFieldName($field)) return;
             $value = $filter['value'];
             $logic = strtolower($filter['logic'] ?? 'and');
 
@@ -128,6 +129,7 @@ class UserController extends Controller
 
         collect($request->input('sort'))->each(function ($sort) use ($builder) {
             $field = $sort['id'];
+            if (!$this->isValidFieldName($field)) return;
             $direction = $sort['desc'] ? 'DESC' : 'ASC';
             $builder->orderBy($field, $direction);
         });

--- a/app/Traits/QueryOperators.php
+++ b/app/Traits/QueryOperators.php
@@ -7,6 +7,21 @@ use Illuminate\Contracts\Database\Query\Expression;
 trait QueryOperators
 {
     /**
+     * Validate that a user-controlled field name is safe for use in query
+     * builder methods (where/orderBy) that take identifiers verbatim. Blocks
+     * SQL injection via column-name payloads like `email, (SELECT …)`.
+     *
+     * Accepts: plain identifier (`email`) or one-level dot notation (`user.email`).
+     *
+     * @param string $field
+     * @return bool
+     */
+    protected function isValidFieldName(string $field): bool
+    {
+        return (bool) preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)?$/', $field);
+    }
+
+    /**
      * 获取查询运算符映射
      *
      * @param string $operator


### PR DESCRIPTION
## Summary

The admin User/Order/Coupon/Ticket list endpoints accept `filter[].id` and `sort[].id` taken verbatim from the request body, then pass the string into `->where(\$field, …)` / `->orderBy(\$field, …)`. Laravel quotes the *value* but treats the first argument as a **raw identifier** — so a valid admin JWT can supply column-name payloads like `email), (SELECT …) --` to influence the emitted SQL.

**Impact**: authenticated SQL-like injection via column-name payloads. Requires an admin token but not any elevated privilege beyond \"list users\" / \"list orders\". Worst case: data exfiltration via time-based or boolean-based probing of the column name parser.

## Fix

Central `isValidFieldName()` regex in `QueryOperators` trait, allowing a plain identifier (`email`) or one-level dot notation (`plan.name` for relation filters). Admin controllers call it before building the query; invalid inputs silently drop that one filter/sort entry (matches existing \"ignore unknown filter\" UX).

```php
protected function isValidFieldName(string \$field): bool
{
    return (bool) preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*(\\\\.[a-zA-Z_][a-zA-Z0-9_]*)?\$/', \$field);
}
```

## Changes

| File | Change |
|---|---|
| `app/Traits/QueryOperators.php` | add `isValidFieldName()` |
| `app/Http/Controllers/V2/Admin/UserController.php` | already uses trait; guard filter/sort |
| `app/Http/Controllers/V2/Admin/OrderController.php` | add trait import + guard |
| `app/Http/Controllers/V2/Admin/CouponController.php` | add trait import + guard |
| `app/Http/Controllers/V2/Admin/TicketController.php` | add trait import + guard |

**+32 / −0** across 5 files.

## Test plan

- [x] \`php -l\` all 5 files
- [x] Legitimate filter `email` / sort `created_at` still works (regex accepts plain idents)
- [x] Relation filter `plan.name` still works (one dot allowed, for `whereHas`)
- [x] Injection payload `email),(SELECT version())` dropped silently — no SQL emitted for that entry
- [x] MySQL + PG + SQLite: identical behavior (fix is driver-agnostic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)