### PR TITLE
fix(security): timing-safe server_token compare + ZipSlip guard in ThemeService

### DIFF
--- a/app/Http/Middleware/Server.php
+++ b/app/Http/Middleware/Server.php
@@ -32,7 +32,8 @@ class Server
             'token' => [
                 'string', 'required',
                 function ($attribute, $value, $fail) {
-                    if ($value !== admin_setting('server_token')) {
+                    // Timing-safe comparison to avoid leaking server_token via response-time side channel
+                    if (!hash_equals((string) admin_setting('server_token'), (string) $value)) {
                         $fail("Invalid {$attribute}");
                     }
                 },

--- a/app/Services/ThemeService.php
+++ b/app/Services/ThemeService.php
@@ -118,6 +118,15 @@ class ThemeService
                 throw new Exception('Theme config file not found');
             }
 
+            // Guard against ZipSlip — refuse packages whose entries traverse outside $tmpPath
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $entryName = $zip->getNameIndex($i);
+                if ($entryName === false || str_contains($entryName, '..') || str_starts_with($entryName, '/')) {
+                    $zip->close();
+                    throw new Exception('Invalid file path detected in theme package');
+                }
+            }
+
             $zip->extractTo($tmpPath);
             $zip->close();
 


### PR DESCRIPTION
## Summary

Two small, independent security hardenings that surfaced during a PG 17 production audit. Bundled because each is a few lines; splitting would make 2 noisy PRs with no shared context cost.

## 1. Timing-safe \`server_token\` comparison — `app/Http/Middleware/Server.php`

The node auth middleware compares the submitted token with \`\$value !== admin_setting('server_token')\`, which short-circuits on the first byte mismatch. Over many probes, an attacker can recover \`server_token\` byte-by-byte via response-time side channel (standard HMAC/token timing-attack class).

Fix: \`hash_equals((string) admin_setting('server_token'), (string) \$value)\` — constant-time comparison.

## 2. ZipSlip guard — `app/Services/ThemeService.php`

\`ThemeService::upload()\` calls \`\$zip->extractTo(\$tmpPath)\` without inspecting entry names. A crafted theme zip with entries like \`../../etc/cron.d/backdoor\` or \`/absolute/path\` writes outside \`\$tmpPath\`. The route is admin-gated, but theme upload is an obvious foothold once a session is compromised (phishing, reused password, etc.).

Fix: iterate \`\$zip->getNameIndex(\$i)\` before extraction and refuse any entry containing \`..\` or starting with \`/\`.

## Test plan

- [x] \`php -l\` on both files
- [x] Legitimate theme zip (e.g. `LiquidGlass/config.json`) still installs fine
- [x] Malicious zip with `../evil.txt` entry → extraction refused with `Invalid file path detected in theme package`
- [x] Node token auth: wrong tokens still rejected; correct tokens still pass (production verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)