### PR TITLE
fix: use bool literals in where() on boolean-cast columns

### DIFF
--- a/app/Console/Commands/CheckTrafficExceeded.php
+++ b/app/Console/Commands/CheckTrafficExceeded.php
@@ -26,7 +26,7 @@ class CheckTrafficExceeded extends Command
             ->whereIn('id', $pendingUserIds)
             ->whereRaw('u + d >= transfer_enable')
             ->where('transfer_enable', '>', 0)
-            ->where('banned', 0)
+            ->where('banned', false)
             ->select(['id', 'group_id'])
             ->get();
 

--- a/app/Console/Commands/ResetTraffic.php
+++ b/app/Console/Commands/ResetTraffic.php
@@ -255,7 +255,7 @@ class ResetTraffic extends Command
         $query->where('expired_at', '>', time())
           ->orWhereNull('expired_at');
       })
-      ->where('banned', 0)
+      ->where('banned', false)
       ->whereNotNull('plan_id');
   }
 
@@ -269,7 +269,7 @@ class ResetTraffic extends Command
         $query->where('expired_at', '>', time())
           ->orWhereNull('expired_at');
       })
-      ->where('banned', 0)
+      ->where('banned', false)
       ->with('plan:id,name,reset_traffic_method')
       ->get();
   }
@@ -281,7 +281,7 @@ class ResetTraffic extends Command
         $query->where('expired_at', '>', time())
           ->orWhereNull('expired_at');
       })
-      ->where('banned', 0)
+      ->where('banned', false)
       ->with('plan:id,name,reset_traffic_method')
       ->get();
   }

--- a/app/Http/Controllers/V1/User/KnowledgeController.php
+++ b/app/Http/Controllers/V1/User/KnowledgeController.php
@@ -77,7 +77,7 @@ class KnowledgeController extends Controller
 
     private function buildKnowledgeQuery(array $select = ['*'])
     {
-        return Knowledge::select($select)->where('show', 1);
+        return Knowledge::select($select)->where('show', true);
     }
 
     private function processKnowledgeContent(array $knowledge, User $user): array

--- a/app/Http/Controllers/V1/User/OrderController.php
+++ b/app/Http/Controllers/V1/User/OrderController.php
@@ -182,7 +182,7 @@ class OrderController extends Controller
             'handling_fee_fixed',
             'handling_fee_percent'
         ])
-            ->where('enable', 1)
+            ->where('enable', true)
             ->orderBy('sort', 'ASC')
             ->get();
 

--- a/app/Observers/PlanObserver.php
+++ b/app/Observers/PlanObserver.php
@@ -18,7 +18,7 @@ class PlanObserver
         }
         $trafficResetService = app(TrafficResetService::class);
         User::where('plan_id', $plan->id)
-            ->where('banned', 0)
+            ->where('banned', false)
             ->where(function ($query) {
                 $query->where('expired_at', '>', time())
                     ->orWhereNull('expired_at');

--- a/app/Observers/ServerRouteObserver.php
+++ b/app/Observers/ServerRouteObserver.php
@@ -20,7 +20,7 @@ class ServerRouteObserver
 
     private function notifyAffectedNodes(int $routeId): void
     {
-        $servers = Server::where('show', 1)->get()->filter(
+        $servers = Server::where('show', true)->get()->filter(
             fn ($s) => in_array($routeId, $s->route_ids ?? [])
         );
 

--- a/app/Services/ServerService.php
+++ b/app/Services/ServerService.php
@@ -100,7 +100,7 @@ class ServerService
                 $query->where('expired_at', '>=', time())
                     ->orWhere('expired_at', NULL);
             })
-            ->where('banned', 0)
+            ->where('banned', false)
             ->select([
                 'id',
                 'uuid',

--- a/app/Services/TelegramService.php
+++ b/app/Services/TelegramService.php
@@ -116,8 +116,8 @@ class TelegramService
     {
         $query = User::where('telegram_id', '!=', null);
         $query->where(
-            fn($q) => $q->where('is_admin', 1)
-                ->when($isStaff, fn($q) => $q->orWhere('is_staff', 1))
+            fn($q) => $q->where('is_admin', true)
+                ->when($isStaff, fn($q) => $q->orWhere('is_staff', true))
         );
         $users = $query->get();
         foreach ($users as $user) {

--- a/app/Services/TrafficResetService.php
+++ b/app/Services/TrafficResetService.php
@@ -273,7 +273,7 @@ class TrafficResetService
             $query->where('expired_at', '>', time())
               ->orWhereNull('expired_at');
           })
-          ->where('banned', 0)
+          ->where('banned', false)
           ->whereNotNull('plan_id')
           ->orderBy('id')
           ->limit($batchSize)

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -60,7 +60,7 @@ class UserService
                 $query->where('expired_at', '>=', time())
                     ->orWhere('expired_at', NULL);
             })
-            ->where('banned', 0)
+            ->where('banned', false)
             ->get();
     }
 


### PR DESCRIPTION
## Summary

User/Coupon/Plan/Server/Notice/Payment models cast columns like `banned`, `show`, `enable`, `is_admin`, `is_staff`, `renew`, `sell`, `is_enabled`, `rate_time_enable`, `remind_expire`, `remind_traffic`, `commission_auto_check` as `'boolean'`. The query-builder calls that filter on those columns use `->where('col', 0)` / `->where('col', 1)` — which is fine on MySQL \`tinyint\` columns but:

- **PG with native `boolean` column** raises \`operator does not exist: boolean = integer\` — the PG driver does not coerce integers to bool. Installs that migrated `banned`/etc. to `bool` (common with Laravel migration helpers) are broken today.
- **MySQL strict mode + PHP 8.2+** with a `'boolean'` cast round-trip emits deprecation warnings.
- **Readability** — `where('banned', 0)` reads as \"banned = 0\"; `where('banned', false)` reads as \"not banned.\"

## Changes

13 edits across 10 files, replacing `0`/`1` with `false`/`true`:

| File | Column(s) |
|---|---|
| `app/Console/Commands/CheckTrafficExceeded.php` | banned |
| `app/Console/Commands/ResetTraffic.php` | banned (×3) |
| `app/Services/UserService.php` | banned |
| `app/Services/ServerService.php` | banned |
| `app/Services/TrafficResetService.php` | banned |
| `app/Services/TelegramService.php` | is_admin, is_staff |
| `app/Observers/PlanObserver.php` | banned |
| `app/Observers/ServerRouteObserver.php` | show |
| `app/Http/Controllers/V1/User/KnowledgeController.php` | show |
| `app/Http/Controllers/V1/User/OrderController.php` | enable |

**+13 / −13**. No new logic, no behavior change on MySQL (driver coerces both literals identically), unblocks installs on PG.

## Test plan

- [x] \`php -l\` on all 10 files
- [x] MySQL 8 smoke: knowledge list, user availability query, Telegram admin notify — identical result sets
- [x] PG 17 production: all 10 call sites exercised, no `operator does not exist` errors (were silently failing on tinyint-but-bool-casted path before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)