### PR TITLE
fix(docker): only chown /data when built-in Redis is enabled

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -148,5 +148,10 @@ echo "[entrypoint] Starting services (caddy=${ENABLE_CADDY} web=${ENABLE_WEB} ho
 # PIDs left over from a previous container run (causes Swoole kill EPERM).
 rm -f /www/storage/logs/octane-server-state.json /www/storage/logs/xboard-ws-server.pid 2>/dev/null || true
 chown -R www:www /www 2>/dev/null || true
-chown redis:redis /data 2>/dev/null || true
+# Only adjust /data ownership when running the built-in Redis (all-in-one mode).
+# In split deployments the redis-data volume is shared with redis:7-alpine which
+# uses a different UID/GID; unconditional chown breaks its write permissions.
+if [ "${ENABLE_REDIS}" = "true" ]; then
+    chown redis:redis /data 2>/dev/null || true
+fi
 exec "$@"


### PR DESCRIPTION
In split deployments (redis:7-alpine as a separate container), the unconditional chown redis:redis /data changed the shared volume ownership to the xboard image's redis UID/GID (101:102), breaking the external redis container (UID/GID 999:1000) and triggering MISCONF write errors.

Guard the chown behind ENABLE_REDIS=true so it only runs in all-in-one mode where the built-in Redis is managed by this container.