### PR TITLE
feat: Add TSUNAMI protocol support

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -66,6 +66,7 @@ class Server extends Model
     public const TYPE_TUIC = 'tuic';
     public const TYPE_SHADOWSOCKS = 'shadowsocks';
     public const TYPE_ANYTLS = 'anytls';
+    public const TYPE_TSUNAMI = 'tsunami';
     public const TYPE_SOCKS = 'socks';
     public const TYPE_NAIVE = 'naive';
     public const TYPE_HTTP = 'http';
@@ -104,6 +105,7 @@ class Server extends Model
         self::TYPE_TUIC,
         self::TYPE_SHADOWSOCKS,
         self::TYPE_ANYTLS,
+        self::TYPE_TSUNAMI,
         self::TYPE_SOCKS,
         self::TYPE_NAIVE,
         self::TYPE_HTTP,
@@ -303,6 +305,27 @@ class Server extends Model
                 ]
             ],
             'tls' => self::TLS_CONFIGURATION
+        ],
+        self::TYPE_TSUNAMI => [
+            'padding_scheme' => [
+                'type' => 'array',
+                'default' => [
+                    "stop=8",
+                    "0=30-30",
+                    "1=100-400",
+                    "2=400-500,c,500-1000,c,500-1000,c,500-1000,c,500-1000",
+                    "3=9-9,500-1000",
+                    "4=500-1000",
+                    "5=500-1000",
+                    "6=500-1000",
+                    "7=500-1000"
+                ]
+            ],
+            'fallback_addr' => ['type' => 'string', 'default' => null],
+            'surge_mode' => ['type' => 'string', 'default' => 'auto'],
+            'max_connections' => ['type' => 'integer', 'default' => 4],
+            'surge_threshold' => ['type' => 'integer', 'default' => 8],
+            'tls' => self::TLS_CONFIGURATION,
         ],
         self::TYPE_SOCKS => [
             'tls' => ['type' => 'integer', 'default' => 0],

--- a/app/Protocols/ClashMeta.php
+++ b/app/Protocols/ClashMeta.php
@@ -22,6 +22,7 @@ class ClashMeta extends AbstractProtocol
         Server::TYPE_HYSTERIA,
         Server::TYPE_TUIC,
         Server::TYPE_ANYTLS,
+        Server::TYPE_TSUNAMI,
         Server::TYPE_SOCKS,
         Server::TYPE_HTTP,
         Server::TYPE_MIERU,
@@ -180,6 +181,10 @@ class ClashMeta extends AbstractProtocol
             }
             if ($item['type'] === Server::TYPE_ANYTLS) {
                 array_push($proxy, self::buildAnyTLS($item['password'], $item));
+                array_push($proxies, $item['name']);
+            }
+            if ($item['type'] === Server::TYPE_TSUNAMI) {
+                array_push($proxy, self::buildTsunami($item['password'], $item));
                 array_push($proxies, $item['name']);
             }
             if ($item['type'] === Server::TYPE_SOCKS) {
@@ -679,6 +684,35 @@ class ClashMeta extends AbstractProtocol
         }
         if ($allowInsecure = data_get($protocol_settings, 'tls.allow_insecure')) {
             $array['skip-cert-verify'] = (bool) $allowInsecure;
+        }
+        self::appendEch($array, data_get($protocol_settings, 'tls.ech'));
+
+        return $array;
+    }
+
+    public static function buildTsunami($password, $server)
+    {
+        $protocol_settings = data_get($server, 'protocol_settings', []);
+        $array = [
+            'name' => $server['name'],
+            'type' => 'tsunami',
+            'server' => $server['host'],
+            'port' => $server['port'],
+            'password' => $password,
+            'udp' => true,
+        ];
+
+        if ($serverName = data_get($protocol_settings, 'tls.server_name')) {
+            $array['sni'] = $serverName;
+        }
+        if ($allowInsecure = data_get($protocol_settings, 'tls.allow_insecure')) {
+            $array['skip-cert-verify'] = (bool) $allowInsecure;
+        }
+        if ($maxConn = data_get($protocol_settings, 'max_connections')) {
+            $array['max-connections'] = (int) $maxConn;
+        }
+        if ($threshold = data_get($protocol_settings, 'surge_threshold')) {
+            $array['surge-threshold'] = (int) $threshold;
         }
         self::appendEch($array, data_get($protocol_settings, 'tls.ech'));
 

--- a/app/Protocols/SingBox.php
+++ b/app/Protocols/SingBox.php
@@ -18,6 +18,7 @@ class SingBox extends AbstractProtocol
         Server::TYPE_HYSTERIA,
         Server::TYPE_TUIC,
         Server::TYPE_ANYTLS,
+        Server::TYPE_TSUNAMI,
         Server::TYPE_SOCKS,
         Server::TYPE_HTTP,
     ];
@@ -168,6 +169,10 @@ class SingBox extends AbstractProtocol
             if ($item['type'] === Server::TYPE_ANYTLS) {
                 $anytlsConfig = $this->buildAnyTLS($this->user['uuid'], $item);
                 $proxies[] = $anytlsConfig;
+            }
+            if ($item['type'] === Server::TYPE_TSUNAMI) {
+                $tsunamiConfig = $this->buildTsunami($this->user['uuid'], $item);
+                $proxies[] = $tsunamiConfig;
             }
             if ($item['type'] === Server::TYPE_SOCKS) {
                 $socksConfig = $this->buildSocks($this->user['uuid'], $item);
@@ -783,6 +788,36 @@ class SingBox extends AbstractProtocol
 
         if ($serverName = data_get($protocol_settings, 'tls.server_name')) {
             $array['tls']['server_name'] = $serverName;
+        }
+        $this->appendEch($array['tls'], data_get($protocol_settings, 'tls.ech'));
+
+        return $array;
+    }
+
+    protected function buildTsunami($password, $server): array
+    {
+        $protocol_settings = data_get($server, 'protocol_settings', []);
+        $array = [
+            'type' => 'tsunami',
+            'tag' => $server['name'],
+            'server' => $server['host'],
+            'password' => $password,
+            'server_port' => $server['port'],
+            'tls' => [
+                'enabled' => true,
+                'insecure' => (bool) data_get($protocol_settings, 'tls.allow_insecure', false),
+                'alpn' => ['h2'],
+            ]
+        ];
+
+        if ($serverName = data_get($protocol_settings, 'tls.server_name')) {
+            $array['tls']['server_name'] = $serverName;
+        }
+        if ($maxConn = data_get($protocol_settings, 'max_connections')) {
+            $array['max_connections'] = (int) $maxConn;
+        }
+        if ($threshold = data_get($protocol_settings, 'surge_threshold')) {
+            $array['surge_threshold'] = (int) $threshold;
         }
         $this->appendEch($array['tls'], data_get($protocol_settings, 'tls.ech'));
 

--- a/app/Services/ServerService.php
+++ b/app/Services/ServerService.php
@@ -342,6 +342,17 @@ class ServerService
                 'tls_settings' => $protocolSettings['tls'],
                 'padding_scheme' => $protocolSettings['padding_scheme'],
             ],
+            'tsunami' => [
+                ...$baseConfig,
+                'server_port' => (int) $serverPort,
+                'server_name' => $protocolSettings['tls']['server_name'],
+                'tls_settings' => $protocolSettings['tls'],
+                'padding_scheme' => $protocolSettings['padding_scheme'],
+                'fallback_addr' => $protocolSettings['fallback_addr'],
+                'surge_mode' => $protocolSettings['surge_mode'],
+                'max_connections' => (int) $protocolSettings['max_connections'],
+                'surge_threshold' => (int) $protocolSettings['surge_threshold'],
+            ],
             'socks' => [
                 ...$baseConfig,
                 'server_port' => (int) $serverPort,


### PR DESCRIPTION
## Summary
Add first-class TSUNAMI protocol support to Xboard panel.

## Changes
- **Server.php**: Add `TYPE_TSUNAMI` constant, include in `VALID_TYPES`, define protocol configurations (TLS, padding, surge)
- **ServerService.php**: Add tsunami node configuration builder in `buildNodeConfig`  
- **ClashMeta.php**: Add `buildTsunami()` method for subscription generation
- **SingBox.php**: Add `buildTsunami()` method for subscription generation

## Protocol Details
- TLS 1.3 with ALPN `h2` and uTLS fingerprinting
- Authentication via `SHA-256(uuid)` (consistent with Trojan/AnyTLS)
- Programmable padding scheme for traffic obfuscation
- Surge adaptive multiplexing (auto mode: MaxConnections=4, SurgeThreshold=8)
- Fallback address support for failed authentication

## Testing
- Syntax validated
- Follows existing protocol patterns (ClashMeta/SingBox subscription format)