### PR TITLE
Fix(Shadowrocket) TUIC congestion control

### DIFF
--- a/app/Protocols/Shadowrocket.php
+++ b/app/Protocols/Shadowrocket.php
@@ -412,6 +412,7 @@ class Shadowrocket extends AbstractProtocol
             'alpn' => data_get($protocol_settings, 'alpn'),
             'sni' => data_get($protocol_settings, 'tls.server_name'),
             'insecure' => data_get($protocol_settings, 'tls.allow_insecure')
+            'congestion_control' => data_get($protocol_settings, 'congestion_control', 'cubic')
         ];
         if (data_get($protocol_settings, 'version') === 4) {
             $params['token'] = $password;


### PR DESCRIPTION
Fixes an issue where the TUIC congestion_control parameter was not being passed to clients on Shadowrocket. This PR adds the missing parameter to the URL query string, fetching it from $protocol_settings with a default and safe fallback to 'cubic', ensuring panel configurations are properly respected by the client.