### PR TITLE
Rename v2_order.refund_amount to surplus_credit

### DIFF
--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int $total_amount
  * @property int|null $handling_amount
  * @property int|null $balance_amount
- * @property int|null $refund_amount
+ * @property int|null $surplus_credit
  * @property int|null $surplus_amount
  * @property int $type
  * @property int $status

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -103,8 +103,8 @@ class OrderService
         DB::transaction(function () use ($order, $plan) {
             $this->user = User::lockForUpdate()->find($order->user_id);
 
-            if ($order->refund_amount) {
-                $this->user->balance += $order->refund_amount;
+            if ($order->surplus_credit) {
+                $this->user->balance += $order->surplus_credit;
             }
 
             if ($order->surplus_order_ids) {
@@ -158,7 +158,7 @@ class OrderService
             if ((int) admin_setting('surplus_enable', 1))
                 $this->getSurplusValue($user, $order);
             if ($order->surplus_amount >= $order->total_amount) {
-                $order->refund_amount = (int) ($order->surplus_amount - $order->total_amount);
+                $order->surplus_credit = (int) ($order->surplus_amount - $order->total_amount);
                 $order->total_amount = 0;
             } else {
                 $order->total_amount = (int) ($order->total_amount - $order->surplus_amount);
@@ -256,7 +256,7 @@ class OrderService
                 return;
             }
 
-            $orderAmountSum = $orders->sum(fn($item) => $item->total_amount + $item->balance_amount + $item->surplus_amount - $item->refund_amount);
+            $orderAmountSum = $orders->sum(fn($item) => $item->total_amount + $item->balance_amount + $item->surplus_amount - $item->surplus_credit);
             $orderMonthSum = $orders->sum(fn($item) => self::STR_TO_TIME[PlanService::getPeriodKey($item->period)] ?? 0);
             $firstOrderAt = $orders->min('created_at');
             $expiredAt = Carbon::createFromTimestamp($firstOrderAt)->addMonths($orderMonthSum);

--- a/database/migrations/2026_05_30_000000_rename_refund_amount_to_surplus_credit.php
+++ b/database/migrations/2026_05_30_000000_rename_refund_amount_to_surplus_credit.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('v2_order', function (Blueprint $table) {
+            $table->renameColumn('refund_amount', 'surplus_credit');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('v2_order', function (Blueprint $table) {
+            $table->renameColumn('surplus_credit', 'refund_amount');
+        });
+    }
+};


### PR DESCRIPTION
The old name was misleading.

this column tracks surplus credit returned to the user's internal balance during plan upgrades, not a payment gateway refund. The new name aligns with the existing surplus_amount and surplus_order_ids naming convention.

The change has been tested, the migration is clean.

This commit may seem like no big deal, but its important if we want to avoid confusion when later adding actual refund feature