### PR TITLE
fix (General.php): VLESS parsing issue

### DIFF
--- a/app/Protocols/General.php
+++ b/app/Protocols/General.php
@@ -239,7 +239,7 @@ class General extends AbstractProtocol
 
         $user = $uuid . '@' . Helper::wrapIPv6($host) . ':' . $port;
         $query = http_build_query($config);
-        $fragment = urlencode($name);
+        $fragment = rawurlencode($name);
         $link = sprintf("vless://%s?%s#%s\r\n", $user, $query, $fragment);
         return $link;
     }


### PR DESCRIPTION
Replace urlencode with rawurlencode to prevent spaces from being improperly converted to '+' in node names (e.g., 'HKG 01' becoming 'HKG+01'). 

A tiny one-line change that significantly improves the UX.

**Example in V2RayN:**

Before (spaces shown as `+`):
<img width="330" height="63" alt="before" src="https://github.com/user-attachments/assets/810d0463-de10-4d48-a0cf-47102b7a0353" />

After (properly parsed spaces):
<img width="330" height="60" alt="after" src="https://github.com/user-attachments/assets/6fd8c51b-d795-47fc-bbf9-ecc1a2914af8" />