### PR TITLE
fix(UpdateService): stop ~/.gitconfig growing without bound

### DIFF
--- a/app/Services/UpdateService.php
+++ b/app/Services/UpdateService.php
@@ -257,9 +257,11 @@ class UpdateService
     protected function getCurrentCommit(): string
     {
         try {
-            // Ensure git configuration is correct
-            Process::run(sprintf('git config --global --add safe.directory %s', base_path()));
-            $result = Process::run('git rev-parse HEAD');
+            // Pass safe.directory inline instead of appending it to the global git
+            // config. `git config --global --add` appends a duplicate entry on every
+            // call, so ~/.gitconfig grows without bound and every later git command
+            // pays the cost of parsing it.
+            $result = Process::run(sprintf('git -c safe.directory=%s rev-parse HEAD', escapeshellarg(base_path())));
             $fullHash = trim($result->output());
             return $fullHash ? $this->formatCommitHash($fullHash) : 'unknown';
         } catch (\Exception $e) {
@@ -308,8 +310,9 @@ class UpdateService
             // Get current project root directory
             $basePath = base_path();
             
-            // Ensure git configuration is correct
-            Process::run(sprintf('git config --global --add safe.directory %s', $basePath));
+            // Use --replace-all rather than --add so this entry can never accumulate
+            // duplicates in ~/.gitconfig.
+            Process::run(sprintf('git config --global --replace-all safe.directory %s', escapeshellarg($basePath)));
             
             // Pull latest code
             Process::run('git fetch origin master');


### PR DESCRIPTION
## Problem

`git config --global --add safe.directory <path>` **appends a new duplicate entry every time it runs** — it does not deduplicate. `UpdateService` calls it from two paths:

- `getCurrentCommit()` (`app/Services/UpdateService.php:261`)
- `pullLatestCode()` (`app/Services/UpdateService.php:312`)

`getCurrentCommit()` is reachable from ordinary request paths (`getCurrentVersion()` on a cache miss, `checkForUpdates()`, `getUpdateInfo()`), so `~/.gitconfig` gains a line per call and never shrinks.

## Impact observed in production

On a long-running install, `~/.gitconfig` reached **394,297 lines / 7.1 MB**, consisting of one `[safe]` header and 394,296 identical `directory = /www` entries. Git must parse that file on every invocation, so each `git` call cost ~1s:

```
3x git rev-parse HEAD, bloated ~/.gitconfig   3.27s
3x git rev-parse HEAD, single-entry config    0.00s
```

Because `getCurrentCommit()` shells out twice, the affected page served in **~2.05s**, of which ~2.04s was git parsing duplicate `safe.directory` lines. Measured page render, same code path, only the global config differing:

```
bloated config    2060 / 1996 / 2036 ms
clean config        65 /   14 /    6 ms
bloated again     2179 / 2020 / 2024 ms
```

It also degrades silently over time — each request makes the next one slower — and eventually the file grows large enough that `git config` itself starts failing.

## Fix

- `getCurrentCommit()`: pass `safe.directory` inline with `git -c safe.directory=...` so nothing is written to the global config at all.
- `pullLatestCode()`: use `--replace-all` instead of `--add`, so the entry can hold at most one value.
- Quote the path with `escapeshellarg()`, since these command strings are run through a shell.

No behaviour change otherwise — `git rev-parse HEAD` still resolves identically with the inline flag, including on repositories that would otherwise trip git's `detected dubious ownership` check (verified: without `safe.directory` git fails with that error; with `-c safe.directory=...` it returns the hash normally).

## Notes

Existing installs will still carry an inflated `~/.gitconfig`; reducing it to a single `[safe] directory = <path>` entry restores normal git performance immediately.