### PR TITLE
fix: scope traffic logs to the active reset cycle

### DIFF
--- a/app/Http/Controllers/V1/User/StatController.php
+++ b/app/Http/Controllers/V1/User/StatController.php
@@ -4,23 +4,90 @@ namespace App\Http\Controllers\V1\User;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\TrafficLogResource;
+use App\Models\Plan;
 use App\Models\StatUser;
-use App\Services\StatisticalService;
+use App\Models\TrafficResetLog;
+use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class StatController extends Controller
 {
     public function getTrafficLog(Request $request)
     {
-        $startDate = now()->startOfMonth()->timestamp;
+        /** @var User $user */
+        $user = $request->user()->loadMissing('plan');
+        $cycleStart = $this->getCurrentTrafficCycleStart($user)->startOfDay()->timestamp;
+        $nextResetAt = (int) ($user->getRawOriginal('next_reset_at') ?? 0);
+
         $records = StatUser::query()
-            ->where('user_id', $request->user()->id)
-            ->where('record_at', '>=', $startDate)
+            ->where('user_id', $user->id)
+            ->where('record_type', 'd')
+            ->where('record_at', '>=', $cycleStart)
+            ->when($nextResetAt > 0, fn ($query) => $query->where('record_at', '<', $nextResetAt))
+            ->where('record_at', '<=', now()->endOfDay()->timestamp)
             ->orderBy('record_at', 'DESC')
             ->get();
 
-        $data = TrafficLogResource::collection(collect($records));
-        return $this->success($data);
+        return $this->success(TrafficLogResource::collection($records));
+    }
+
+    private function getCurrentTrafficCycleStart(User $user): Carbon
+    {
+        $timezone = config('app.timezone');
+        $createdAt = Carbon::createFromTimestamp(
+            (int) ($user->getRawOriginal('created_at') ?? time()),
+            $timezone
+        );
+        $lastResetAt = (int) ($user->getRawOriginal('last_reset_at') ?? 0);
+
+        if ($lastResetAt > 0) {
+            return $this->latestOf(
+                Carbon::createFromTimestamp($lastResetAt, $timezone),
+                $createdAt
+            );
+        }
+
+        /** @var TrafficResetLog|null $lastResetLog */
+        $lastResetLog = $user->trafficResetLogs()
+            ->orderByDesc('reset_time')
+            ->first();
+        if ($lastResetLog?->reset_time) {
+            return $this->latestOf(
+                $lastResetLog->reset_time->copy()->timezone($timezone),
+                $createdAt
+            );
+        }
+
+        $nextResetAt = (int) ($user->getRawOriginal('next_reset_at') ?? 0);
+        if ($nextResetAt <= 0) {
+            return $createdAt;
+        }
+
+        $resetMethod = $user->plan?->reset_traffic_method;
+        if ($resetMethod === Plan::RESET_TRAFFIC_FOLLOW_SYSTEM) {
+            $resetMethod = (int) admin_setting(
+                'reset_traffic_method',
+                Plan::RESET_TRAFFIC_MONTHLY
+            );
+        }
+
+        $nextReset = Carbon::createFromTimestamp($nextResetAt, $timezone);
+        $inferredStart = match ($resetMethod) {
+            Plan::RESET_TRAFFIC_FIRST_DAY_YEAR,
+            Plan::RESET_TRAFFIC_YEARLY => $nextReset->copy()->subYearNoOverflow(),
+            Plan::RESET_TRAFFIC_FIRST_DAY_MONTH,
+            Plan::RESET_TRAFFIC_MONTHLY => $nextReset->copy()->subMonthNoOverflow(),
+            default => null,
+        };
+
+        return $inferredStart
+            ? $this->latestOf($inferredStart, $createdAt)
+            : $createdAt;
+    }
+
+    private function latestOf(Carbon $first, Carbon $second): Carbon
+    {
+        return $first->greaterThan($second) ? $first : $second;
     }
 }

--- a/tests/Feature/User/TrafficLogTest.php
+++ b/tests/Feature/User/TrafficLogTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Feature\User;
+
+use App\Http\Controllers\V1\User\StatController;
+use App\Models\Plan;
+use App\Models\StatUser;
+use App\Models\TrafficResetLog;
+use App\Models\User;
+use App\Utils\Helper;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Http\Request;
+
+class TrafficLogTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('app.key', 'base64:' . base64_encode(str_repeat('a', 32)));
+        config()->set('app.timezone', 'Asia/Shanghai');
+        Carbon::setTestNow(Carbon::create(2026, 8, 14, 12, 0, 0, 'Asia/Shanghai'));
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_it_returns_only_daily_records_from_the_last_reset_day(): void
+    {
+        $user = $this->createUser([
+            'last_reset_at' => $this->timestamp('2026-08-10 15:00:00'),
+            'next_reset_at' => $this->timestamp('2026-09-10 15:00:00'),
+        ]);
+
+        $this->createStat($user, '2026-08-09', 'd');
+        $resetDay = $this->createStat($user, '2026-08-10', 'd');
+        $currentDay = $this->createStat($user, '2026-08-11', 'd');
+        $this->createStat($user, '2026-08-11', 'm');
+
+        $this->assertSame(
+            [$currentDay->record_at, $resetDay->record_at],
+            $this->trafficRecordDates($user)
+        );
+    }
+
+    public function test_it_infers_the_cycle_from_the_next_monthly_reset(): void
+    {
+        $user = $this->createUser([
+            'created_at' => $this->timestamp('2026-06-01 00:00:00'),
+            'next_reset_at' => $this->timestamp('2026-08-20 00:00:00'),
+        ]);
+
+        $this->createStat($user, '2026-07-19', 'd');
+        $cycleStart = $this->createStat($user, '2026-07-20', 'd');
+
+        $this->assertSame([$cycleStart->record_at], $this->trafficRecordDates($user));
+    }
+
+    public function test_it_uses_the_latest_reset_log_when_user_reset_fields_are_missing(): void
+    {
+        $user = $this->createUser([
+            'created_at' => $this->timestamp('2026-06-01 00:00:00'),
+            'next_reset_at' => null,
+            'last_reset_at' => null,
+        ]);
+
+        TrafficResetLog::query()->create([
+            'user_id' => $user->id,
+            'reset_type' => TrafficResetLog::TYPE_MANUAL,
+            'reset_time' => Carbon::create(2026, 8, 5, 16, 0, 0, 'Asia/Shanghai'),
+            'old_upload' => 100,
+            'old_download' => 200,
+            'old_total' => 300,
+            'new_upload' => 0,
+            'new_download' => 0,
+            'new_total' => 0,
+            'trigger_source' => TrafficResetLog::SOURCE_MANUAL,
+        ]);
+
+        $this->createStat($user, '2026-08-04', 'd');
+        $resetDay = $this->createStat($user, '2026-08-05', 'd');
+
+        $this->assertSame([$resetDay->record_at], $this->trafficRecordDates($user));
+    }
+
+    private function createUser(array $overrides = []): User
+    {
+        $now = $this->timestamp('2026-06-01 00:00:00');
+        $plan = Plan::query()->create([
+            'group_id' => 1,
+            'transfer_enable' => 100,
+            'name' => 'Monthly plan',
+            'reset_traffic_method' => Plan::RESET_TRAFFIC_MONTHLY,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $user = User::query()->create(array_merge([
+            'email' => Helper::guid(true) . '@example.com',
+            'password' => password_hash('password', PASSWORD_DEFAULT),
+            'uuid' => Helper::guid(true),
+            'token' => Helper::guid(true),
+            'plan_id' => $plan->id,
+            'group_id' => 1,
+            'expired_at' => $this->timestamp('2027-01-01 00:00:00'),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ], $overrides));
+
+        // UserObserver calculates next_reset_at on create. Restore explicit
+        // timestamps so each test controls the cycle boundary it exercises.
+        $user->forceFill($overrides)->saveQuietly();
+
+        return $user->refresh();
+    }
+
+    private function createStat(User $user, string $date, string $recordType): StatUser
+    {
+        return StatUser::query()->create([
+            'user_id' => $user->id,
+            'server_rate' => 1,
+            'u' => 100,
+            'd' => 200,
+            'record_type' => $recordType,
+            'record_at' => $this->timestamp("{$date} 00:00:00"),
+            'created_at' => Carbon::now()->timestamp,
+            'updated_at' => Carbon::now()->timestamp,
+        ]);
+    }
+
+    private function trafficRecordDates(User $user): array
+    {
+        $request = Request::create('/api/v1/user/stat/getTrafficLog');
+        $request->setUserResolver(fn () => $user);
+
+        $response = app(StatController::class)->getTrafficLog($request);
+
+        return array_column($response->getData(true)['data'], 'record_at');
+    }
+
+    private function timestamp(string $date): int
+    {
+        return Carbon::parse($date, 'Asia/Shanghai')->timestamp;
+    }
+}


### PR DESCRIPTION
## What changed

- scope user traffic-log queries to the user's active traffic reset cycle instead of the calendar month
- prefer `last_reset_at`, fall back to the latest reset log, and infer the cycle from `next_reset_at` for users who have not reset yet
- clamp inferred cycle starts to account creation time and return only daily statistics up to the current day
- add regression coverage for explicit reset timestamps, inferred monthly cycles, and reset-log fallback

## Why

`getTrafficLog` always started at the first day of the current calendar month. That does not match anniversary-based monthly plans, yearly plans, or manual/purchase resets. Users could therefore see traffic from a previous quota cycle or lose valid records from the current one.

## Impact

The endpoint now reflects the same reset boundaries used by Xboard's traffic reset subsystem. Existing first-day-of-month plans retain their current behavior, while custom cycles return the correct range.

## Validation

- PHPUnit: 3 tests, 3 assertions passed with an isolated in-memory SQLite database
  - `APP_ENV=testing DB_CONNECTION=sqlite DATABASE_URL=sqlite:///:memory: vendor/bin/phpunit --process-isolation --bootstrap vendor/autoload.php tests/Feature/User/TrafficLogTest.php`
- `vendor/bin/phpstan analyse --no-progress app/Http/Controllers/V1/User/StatController.php tests/Feature/User/TrafficLogTest.php`
- PHP syntax checks for both changed files
- `git diff --check upstream/master...HEAD`
