### PR TITLE
fix: return full node config in MachineController::nodes()

### DIFF
--- a/app/Http/Controllers/V2/Server/MachineController.php
+++ b/app/Http/Controllers/V2/Server/MachineController.php
@@ -22,11 +22,13 @@ class MachineController extends Controller
         $machine = $this->authenticateMachine($request);
 
         $nodes = ServerService::getMachineNodes($machine)
-            ->map(fn($node) => [
-                'id' => $node->id,
-                'type' => $node->type,
-                'name' => $node->name,
-            ])->values();
+            ->map(function ($node) {
+                $config = \App\Services\ServerService::buildNodeConfig($node);
+                $config['id'] = $node->id;
+                $config['type'] = $node->type;
+                $config['name'] = $node->name;
+                return $config;
+            })->values();
 
         return response()->json([
             'nodes' => $nodes,


### PR DESCRIPTION
## Problem

When using xboard-node agent in machine mode, the agent fails to start TLS-based protocol nodes (hysteria2, trojan, vless, tuic, anytls) with error:

```
ERROR [core] machine node exited with error node_id=X error=initial setup: protocol "hysteria" requires TLS certificate files
```

## Root Cause

`MachineController::nodes()` only returns `{id, type, name}`, without `protocol_settings` or `cert_config`. The xboard-node agent calls this endpoint at startup and immediately attempts to start nodes. While a WebSocket connection is established (`ws mux started`), the agent does not wait for WebSocket-pushed configuration before attempting to start nodes.

The agent needs the full node configuration (especially `cert_config`) to set up TLS for hysteria2 and other TLS-based protocols.

## Solution

Include `ServerService::buildNodeConfig()` output in the `nodes()` response, so the agent receives complete node configuration including `cert_config`, `protocol_settings`, `server_port`, etc.

This is the same data that the legacy `UniProxy/config` endpoint returns for non-machine mode nodes. Machine mode nodes currently have no equivalent way to receive full configuration.

## Changes

Only `app/Http/Controllers/V2/Server/MachineController.php` modified (1 method, +7 -5 lines).

```diff
- ->map(fn($node) => [
-     'id' => $node->id,
-     'type' => $node->type,
-     'name' => $node->name,
- ])->values();
+ ->map(function ($node) {
+     $config = \App\Services\ServerService::buildNodeConfig($node);
+     $config['id'] = $node->id;
+     $config['type'] = $node->type;
+     $config['name'] = $node->name;
+     return $config;
+ })->values();
```

## Testing

- **Environment**: Xboard (compose branch) + xboard-node agent (latest dev) on Ubuntu 22.04
- **Protocol**: hysteria2 with file-based TLS certificates (Let's Encrypt)
- **Before fix**: agent fails with `requires TLS certificate files`
- **After fix**: agent successfully starts hysteria2 on 443/UDP, with working:
  - ✅ Heartbeat reporting (node shows online in panel)
  - ✅ User sync (users pushed via WebSocket)
  - ✅ Traffic statistics
  - ✅ Subscription returns correct node config
- **No breaking changes**: existing fields (id, type, name) still present in response

## Related Issues

- [cedar2025/Xboard-Node#10](https://github.com/cedar2025/Xboard-Node/issues/10) — same TLS cert bug reported by another user