### PR TITLE
fix(Shadowrocket.php): add missing bandwidth params for Hysteria2

### DIFF
--- a/app/Protocols/Shadowrocket.php
+++ b/app/Protocols/Shadowrocket.php
@@ -379,6 +379,8 @@ class Shadowrocket extends AbstractProtocol
             case 2:
                 $params = [
                     "obfs" => 'none',
+                    "upmbps" => data_get($protocol_settings, 'bandwidth.up'),
+                    "downmbps" => data_get($protocol_settings, 'bandwidth.down'),
                     "fastopen" => 1
                 ];
                 if ($serverName = data_get($protocol_settings, 'tls.server_name')) {

--- a/app/Protocols/Shadowrocket.php
+++ b/app/Protocols/Shadowrocket.php
@@ -379,10 +379,14 @@ class Shadowrocket extends AbstractProtocol
             case 2:
                 $params = [
                     "obfs" => 'none',
-                    "upmbps" => data_get($protocol_settings, 'bandwidth.up'),
-                    "downmbps" => data_get($protocol_settings, 'bandwidth.down'),
                     "fastopen" => 1
                 ];
+                if (($upMbps = data_get($protocol_settings, 'bandwidth.up')) > 0) {
+                    $params['upmbps'] = $upMbps;
+                }
+                if (($downMbps = data_get($protocol_settings, 'bandwidth.down')) > 0) {
+                    $params['downmbps'] = $downMbps;
+                }
                 if ($serverName = data_get($protocol_settings, 'tls.server_name')) {
                     $params['peer'] = $serverName;
                 }


### PR DESCRIPTION
Fixes an issue where Hysteria 2 downgrades to non-Brutal congestion control (BBR/Reno) on Shadowrocket clients.

### Root Cause & UI Alignment
According to the [official Hysteria 2 bandwidth negotiation flowchart](https://v2.hysteria.network/zh/docs/advanced/Full-Server-Config/#_7) (Mandarin Chinese), if the server does not set `ignoreClientBandwidth: true` and the client fails to provide bandwidth parameters, the protocol forcibly downgrades to a non-Brutal controller:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/71a61a9d-7978-4824-8b8c-392235444865" />

This PR adds `upmbps` and `downmbps` to the Hy2 `$params` array using `data_get()`. This implementation **perfectly respects the panel's design**. 
- If an admin fills in the bandwidth, the parameters are passed, and Brutal is activated.
- If left blank, the parameters are cleanly omitted, and it correctly falls back to BBR.
- *Note: The code style remains strictly incremental and consistent with the Hysteria 1 (`case 1`) implementation to ensure zero regression risk. I deliberately avoided refactoring or altering the existing logic tree, considering the uncertainty surrounding Hysteria 3 (e.g., whether it will be released or if it will deprecate the Brutal congestion control). This purely additive approach introduces zero performance overhead and keeps the codebase much easier to refactor when the protocol's future roadmap becomes clear.*

### Test Evidence (Shadowrocket Logs)

**[Before this PR - Bug]** 
Even if the admin configured the bandwidth, the parameters were not passed, causing a silent fallback to BBR:
```log
[20:37:21.689] route manager notify current server => {
    port = 443,
    title = 🇭🇰 HKG 01 ⚡,
    hpkp = [REDACTED],
    host = [REDACTED],
    peer = [REDACTED],
    type = Hysteria2,
    udp = 1
} // No bandwidth params
[20:37:26.534] hysteria session <REDACTED> bbr upmbps => auto // Downgraded to BBR
```

**[After this PR]** 
Parameters are correctly parsed, and the Brutal controller is successfully initialized:
```log
[20:52:51.622] route manager notify current server => {
    upmbps = 40,
    port = 443,
    downmbps = 100,
    title = 🇭🇰 HKG 01 ⚡,
    hpkp = [REDACTED],
    host = [REDACTED],
    peer = [REDACTED],
    type = Hysteria2,
    udp = 1
}
[20:52:54.805] hysteria session <REDACTED> brutal upmbps => 5000000 // Note: 5,000,000 Bytes/s = 40 Mbps. (Shadowrocket logs with the wrong unit string here).
```

If the admin intentionally leaves the bandwidth blank in the panel, the parameters are cleanly omitted without passing empty strings, and it safely falls back to BBR as designed:
```log
[21:16:10.112] route manager notify current server => {
    port = 443,
    title = 🇭🇰 HKG 01 ⚡,
    hpkp = [REDACTED],
    host = [REDACTED],
    peer = [REDACTED],
    type = Hysteria2,
    udp = 1
} // Safely omitted, no dirty keys like `upmbps =` and `downmbps =`
[21:16:13.334] hysteria session <REDACTED> bbr upmbps => auto // Expected graceful fallback
```

### Scope & Cross-Client Verification
To ensure ecosystem consistency, I have thoroughly double-checked the other client implementations:

- `SingBox.php` and `ClashMeta.php`: Both are already handling Hysteria 2 bandwidth parameters correctly. No actions needed.

- `General.php` (v2ray / Xray ecosystem): It currently omits these parameters as well. However, I deliberately left it untouched. Mainstream GUI clients in this ecosystem (e.g., **v2rayN** and **v2rayNG**) completely ignore `upmbps` and `downmbps` in the standard URI scheme. Modifying it would bring zero practical UX improvement, so I kept the scope strictly focused to avoid unnecessary changes.