### PR TITLE
fix: return full node config in MachineController::nodes()

### DIFF
--- a/app/Http/Controllers/V2/Server/MachineController.php
+++ b/app/Http/Controllers/V2/Server/MachineController.php
@@ -22,11 +22,13 @@ class MachineController extends Controller
         $machine = $this->authenticateMachine($request);
 
         $nodes = ServerService::getMachineNodes($machine)
-            ->map(fn($node) => [
-                'id' => $node->id,
-                'type' => $node->type,
-                'name' => $node->name,
-            ])->values();
+            ->map(function ($node) {
+                $config = \App\Services\ServerService::buildNodeConfig($node);
+                $config['id'] = $node->id;
+                $config['type'] = $node->type;
+                $config['name'] = $node->name;
+                return $config;
+            })->values();
 
         return response()->json([
             'nodes' => $nodes,


### PR DESCRIPTION
## Problem

The machine/nodes API only returned `{id, type, name}`, missing `protocol_settings` and `cert_config`. This causes xboard-node agent to fail with **'requires TLS certificate files'** for hysteria2 and other TLS-based protocols.

## Fix

Include `ServerService::buildNodeConfig()` output in the response so the agent receives complete node configuration including `cert_config`, `protocol_settings`, `server_port`, etc.

## Testing

Tested with: Xboard (compose branch) + xboard-node agent (latest dev)
Protocol: hysteria2 with file-based TLS certificates
Result: agent successfully starts hysteria2 on 443/UDP, heartbeat reporting, user sync, and traffic stats all working correctly.

## Compatibility

No breaking changes: existing fields (`id`, `type`, `name`) are still present in the response. New fields are additive.

Related: cedar2025/Xboard-Node#10