### PR TITLE
feat(machine): remote control channel — reload/restart via WS

### DIFF
--- a/app/Console/Commands/CheckMachineOffline.php
+++ b/app/Console/Commands/CheckMachineOffline.php
@@ -12,9 +12,50 @@ use Illuminate\Support\Facades\Log;
 class CheckMachineOffline extends Command
 {
     protected $signature = 'check:machine-offline';
-    protected $description = 'Alert admin when a machine heartbeats out (3 push intervals)';
+    protected $description = 'Alert admin when a machine heartbeats out (3 push intervals) or sustains high load';
 
     private const ALERT_STATE_KEY = 'machine_offline_alert_state';
+
+    // 高负载判定阈值（可被 admin_setting 覆盖）；连续 HIGH_LOAD_ROUNDS 轮超限才告警（1 分钟/轮）
+    private const HIGH_LOAD_ROUNDS = 5;
+
+    private function checkHighLoad(ServerMachine $machine, array $alertState, array &$newState): void
+    {
+        $cpuLimit = (float) (admin_setting('machine_alert_cpu_threshold', 90));
+        $memLimit = (float) (admin_setting('machine_alert_mem_threshold', 90));
+        $load = $machine->load_status ?? [];
+        $cpu = (float) ($load['cpu'] ?? 0);
+        $memUsed = (int) ($load['mem']['used'] ?? 0);
+        $memTotal = (int) ($load['mem']['total'] ?? 0);
+        $memPct = $memTotal > 0 ? $memUsed / $memTotal * 100 : 0;
+        $high = $cpu >= $cpuLimit || $memPct >= $memLimit;
+
+        $roundsKey = "machine_highload_rounds_{$machine->id}";
+        $alertedKey = "machine_highload_alerted_{$machine->id}";
+        $rounds = (int) Cache::get($roundsKey, 0);
+
+        if (!$high) {
+            Cache::forget($roundsKey);
+            if (Cache::get($alertedKey, false)) {
+                Cache::put($alertedKey, false, 86400);
+                $this->notify("🟢 负载恢复: {$machine->name} (#{$machine->id})");
+            }
+            return;
+        }
+
+        $rounds++;
+        if ($rounds >= self::HIGH_LOAD_ROUNDS && !Cache::get($alertedKey, false)) {
+            Cache::put($alertedKey, true, 86400);
+            $this->notify(
+                "🟠 机器高负载: {$machine->name} (#{$machine->id})\n"
+                . sprintf("CPU %.1f%% / 内存 %.1f%%（阈值 %.0f%%/%.0f%%，持续 %d 分钟）", $cpu, $memPct, $cpuLimit, $memLimit, $rounds)
+                . "\nagent: " . ($machine->agent_version ?? 'unknown')
+            );
+            Cache::put($roundsKey, $rounds, 3600);
+            return;
+        }
+        Cache::put($roundsKey, $rounds, 3600);
+    }
 
     public function handle(): int
     {
@@ -39,6 +80,10 @@ class CheckMachineOffline extends Command
                 );
             } elseif (!$offline && $wasOffline) {
                 $this->notify("🟢 机器恢复: {$machine->name} (#{$machine->id})");
+            }
+
+            if (!$offline) {
+                $this->checkHighLoad($machine, $alertState, $newState);
             }
         }
 

--- a/app/Console/Commands/CheckMachineOffline.php
+++ b/app/Console/Commands/CheckMachineOffline.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\SendEmailJob;
+use App\Models\ServerMachine;
+use App\Services\TelegramService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+class CheckMachineOffline extends Command
+{
+    protected $signature = 'check:machine-offline';
+    protected $description = 'Alert admin when a machine heartbeats out (3 push intervals)';
+
+    private const ALERT_STATE_KEY = 'machine_offline_alert_state';
+
+    public function handle(): int
+    {
+        $interval = max(180, (int) admin_setting('server_push_interval', 60) * 3);
+        $threshold = now()->subSeconds($interval)->timestamp;
+
+        $machines = ServerMachine::where('is_active', 1)->get();
+        $alertState = Cache::get(self::ALERT_STATE_KEY, []);
+        $newState = [];
+
+        foreach ($machines as $machine) {
+            $offline = $machine->last_seen_at === null || $machine->last_seen_at < $threshold;
+            $wasOffline = ($alertState[$machine->id] ?? false);
+            $newState[$machine->id] = $offline;
+
+            // 只在状态翻转时告警：上线→下线发告警，下线→上线发恢复
+            if ($offline && !$wasOffline) {
+                $this->notify(
+                    "🔴 机器离线: {$machine->name} (#{$machine->id})\n"
+                    . "最后心跳: " . ($machine->last_seen_at ? date('Y-m-d H:i:s', $machine->last_seen_at) : '从未')
+                    . "\nagent: " . ($machine->agent_version ?? 'unknown')
+                );
+            } elseif (!$offline && $wasOffline) {
+                $this->notify("🟢 机器恢复: {$machine->name} (#{$machine->id})");
+            }
+        }
+
+        // 清理已删除机器的状态
+        Cache::put(self::ALERT_STATE_KEY, array_intersect_key($newState, $machines->keyBy('id')->toArray()), 86400);
+        return self::SUCCESS;
+    }
+
+    private function notify(string $message): void
+    {
+        $this->info($message);
+
+        $chatId = (string) admin_setting('machine_alert_telegram_chat_id', '');
+        if ($chatId !== '') {
+            try {
+                app(TelegramService::class)->sendMessage((int) $chatId, $message);
+                return;
+            } catch (\Throwable $e) {
+                Log::warning('machine offline alert via telegram failed: ' . $e->getMessage());
+            }
+        }
+
+        $email = admin_setting('machine_alert_email', admin_setting('smtp_username', ''));
+        if ($email) {
+            SendEmailJob::dispatch([
+                'email' => $email,
+                'subject' => '[Xboard] 机器状态告警',
+                'template_name' => 'generic',
+                'template_value' => ['content' => $message],
+            ]);
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -32,6 +32,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('xboard:statistics')->dailyAt('0:10')->onOneServer();
         // check
         $schedule->command('check:order')->everyMinute()->onOneServer()->withoutOverlapping(5);
+        $schedule->command('check:machine-offline')->everyMinute()->onOneServer()->withoutOverlapping(5);
         $schedule->command('check:commission')->everyMinute()->onOneServer()->withoutOverlapping(5);
         $schedule->command('check:ticket')->everyMinute()->onOneServer()->withoutOverlapping(5);
         $schedule->command('check:traffic-exceeded')->everyMinute()->onOneServer()->withoutOverlapping(10)->runInBackground();

--- a/app/Http/Controllers/V1/Passport/AuthController.php
+++ b/app/Http/Controllers/V1/Passport/AuthController.php
@@ -74,7 +74,7 @@ class AuthController extends Controller
         $email = $request->input('email');
         $password = $request->input('password');
 
-        [$success, $result] = $this->loginService->login($email, $password);
+        [$success, $result] = $this->loginService->login($email, $password, $request->ip());
 
         if (!$success) {
             return $this->fail($result);

--- a/app/Http/Controllers/V1/User/OrderController.php
+++ b/app/Http/Controllers/V1/User/OrderController.php
@@ -126,6 +126,10 @@ class OrderController extends Controller
         if (!$order) {
             return $this->fail([400, __('Order does not exist or has been paid')]);
         }
+        // negative amounts must never open a subscription for free (#1021)
+        if ($order->total_amount < 0) {
+            return $this->fail([400, __('Order amount is invalid')]);
+        }
         // free process
         if ($order->total_amount <= 0) {
             $orderService = new OrderService($order);

--- a/app/Http/Controllers/V2/Admin/Server/MachineController.php
+++ b/app/Http/Controllers/V2/Admin/Server/MachineController.php
@@ -27,6 +27,10 @@ class MachineController extends Controller
                     'notes' => $machine->notes,
                     'is_active' => $machine->is_active,
                     'last_seen_at' => $machine->last_seen_at,
+                    'agent_version' => $machine->agent_version,
+                    // 离线判定：3 个心跳周期（server_push_interval 默认 60s）无上报视为离线
+                    'is_online' => $machine->last_seen_at !== null
+                        && $machine->last_seen_at > now()->subSeconds(max(180, (int) admin_setting('server_push_interval', 60) * 3))->timestamp,
                     'load_status' => $machine->load_status,
                     'servers_count' => $machine->servers_count,
                     'created_at' => $machine->created_at,

--- a/app/Http/Controllers/V2/Admin/Server/MachineController.php
+++ b/app/Http/Controllers/V2/Admin/Server/MachineController.php
@@ -165,6 +165,50 @@ class MachineController extends Controller
     }
 
     /**
+     * 远程指令：reload（node_id>0 重载单节点，缺省整台机器）
+     */
+    public function controlReload(Request $request)
+    {
+        $params = $request->validate([
+            'machine_id' => 'required|integer|exists:v2_server_machine,id',
+            'node_id' => 'nullable|integer',
+        ]);
+
+        $machine = ServerMachine::findOrFail($params['machine_id']);
+        if (!$machine->is_active) {
+            return $this->fail([400, '机器已停用']);
+        }
+
+        NodeSyncService::pushMachine($machine->id, 'control.reload', array_filter([
+            'node_id' => $params['node_id'] ?? null,
+        ], fn ($v) => $v !== null));
+
+        return $this->success(true);
+    }
+
+    /**
+     * 远程指令：restart（node_id>0 重启单节点进程，缺省重启 agent）
+     */
+    public function controlRestart(Request $request)
+    {
+        $params = $request->validate([
+            'machine_id' => 'required|integer|exists:v2_server_machine,id',
+            'node_id' => 'nullable|integer',
+        ]);
+
+        $machine = ServerMachine::findOrFail($params['machine_id']);
+        if (!$machine->is_active) {
+            return $this->fail([400, '机器已停用']);
+        }
+
+        NodeSyncService::pushMachine($machine->id, 'control.restart', array_filter([
+            'node_id' => $params['node_id'] ?? null,
+        ], fn ($v) => $v !== null));
+
+        return $this->success(true);
+    }
+
+    /**
      * 获取机器负载历史
      */
     public function history(Request $request)

--- a/app/Http/Controllers/V2/Server/MachineController.php
+++ b/app/Http/Controllers/V2/Server/MachineController.php
@@ -22,11 +22,13 @@ class MachineController extends Controller
         $machine = $this->authenticateMachine($request);
 
         $nodes = ServerService::getMachineNodes($machine)
-            ->map(fn($node) => [
-                'id' => $node->id,
-                'type' => $node->type,
-                'name' => $node->name,
-            ])->values();
+            ->map(function ($node) {
+                $config = \App\Services\ServerService::buildNodeConfig($node);
+                $config['id'] = $node->id;
+                $config['type'] = $node->type;
+                $config['name'] = $node->name;
+                return $config;
+            })->values();
 
         return response()->json([
             'nodes' => $nodes,

--- a/app/Http/Controllers/V2/Server/MachineController.php
+++ b/app/Http/Controllers/V2/Server/MachineController.php
@@ -89,6 +89,9 @@ class MachineController extends Controller
         $machine->forceFill([
             'load_status' => $loadStatus,
             'last_seen_at' => $recordedAt,
+            'agent_version' => $request->filled('agent_version')
+                ? substr((string) $request->input('agent_version'), 0, 64)
+                : $machine->agent_version,
         ])->save();
 
         $historyData = [

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -72,6 +72,7 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'user' => \App\Http\Middleware\User::class,
+        'admin.ip.allowlist' => \App\Http\Middleware\AdminIpAllowlist::class,
         'admin' => \App\Http\Middleware\Admin::class,
         'client' => \App\Http\Middleware\Client::class,
         'staff' => \App\Http\Middleware\Staff::class,

--- a/app/Http/Middleware/AdminIpAllowlist.php
+++ b/app/Http/Middleware/AdminIpAllowlist.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\IpUtils;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminIpAllowlist
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $allowlist = trim((string) config('admin.ip_allowlist', ''));
+        if ($allowlist === '') {
+            return $next($request);
+        }
+
+        $entries = array_filter(array_map('trim', explode(',', $allowlist)));
+        if (IpUtils::checkIp((string) $request->ip(), array_values($entries))) {
+            return $next($request);
+        }
+
+        abort(403, 'Admin access from this IP is not allowed.');
+    }
+}

--- a/app/Http/Routes/V1/PassportRoute.php
+++ b/app/Http/Routes/V1/PassportRoute.php
@@ -13,14 +13,16 @@ class PassportRoute
             'prefix' => 'passport'
         ], function ($router) {
             // Auth
-            $router->post('/auth/register', [AuthController::class, 'register']);
-            $router->post('/auth/login', [AuthController::class, 'login']);
-            $router->get('/auth/token2Login', [AuthController::class, 'token2Login']);
-            $router->post('/auth/forget', [AuthController::class, 'forget']);
-            $router->post('/auth/getQuickLoginUrl', [AuthController::class, 'getQuickLoginUrl']);
-            $router->post('/auth/loginWithMailLink', [AuthController::class, 'loginWithMailLink']);
+            $router->group(['middleware' => 'throttle:passport'], function ($router) {
+                $router->post('/auth/register', [AuthController::class, 'register']);
+                $router->post('/auth/login', [AuthController::class, 'login']);
+                $router->get('/auth/token2Login', [AuthController::class, 'token2Login']);
+                $router->post('/auth/forget', [AuthController::class, 'forget']);
+                $router->post('/auth/getQuickLoginUrl', [AuthController::class, 'getQuickLoginUrl']);
+                $router->post('/auth/loginWithMailLink', [AuthController::class, 'loginWithMailLink']);
+            });
             // Comm
-            $router->post('/comm/sendEmailVerify', [CommController::class, 'sendEmailVerify']);
+            $router->post('/comm/sendEmailVerify', [CommController::class, 'sendEmailVerify'])->middleware('throttle:email-verify');
             $router->post('/comm/pv', [CommController::class, 'pv']);
         });
     }

--- a/app/Http/Routes/V2/AdminRoute.php
+++ b/app/Http/Routes/V2/AdminRoute.php
@@ -28,7 +28,7 @@ class AdminRoute
     {
         $router->group([
             'prefix' => admin_setting('secure_path', admin_setting('frontend_admin_path', hash('crc32b', config('app.key')))),
-            'middleware' => ['admin', 'log'],
+            'middleware' => ['admin.ip.allowlist', 'admin', 'log'],
         ], function ($router) {
             // Config
             $router->group([

--- a/app/Http/Routes/V2/AdminRoute.php
+++ b/app/Http/Routes/V2/AdminRoute.php
@@ -108,6 +108,8 @@ class AdminRoute
                 $router->get('/installCommand', [MachineController::class, 'installCommand']);
                 $router->get('/nodes', [MachineController::class, 'nodes']);
                 $router->get('/history', [MachineController::class, 'history']);
+                $router->post('/reload', [MachineController::class, 'controlReload']);
+                $router->post('/restart', [MachineController::class, 'controlRestart']);
             });
 
             // Order

--- a/app/Http/Routes/V2/PassportRoute.php
+++ b/app/Http/Routes/V2/PassportRoute.php
@@ -13,14 +13,16 @@ class PassportRoute
             'prefix' => 'passport'
         ], function ($router) {
             // Auth
-            $router->post('/auth/register', [AuthController::class, 'register']);
-            $router->post('/auth/login', [AuthController::class, 'login']);
-            $router->get ('/auth/token2Login', [AuthController::class, 'token2Login']);
-            $router->post('/auth/forget', [AuthController::class, 'forget']);
-            $router->post('/auth/getQuickLoginUrl', [AuthController::class, 'getQuickLoginUrl']);
-            $router->post('/auth/loginWithMailLink', [AuthController::class, 'loginWithMailLink']);
+            $router->group(['middleware' => 'throttle:passport'], function ($router) {
+                $router->post('/auth/register', [AuthController::class, 'register']);
+                $router->post('/auth/login', [AuthController::class, 'login']);
+                $router->get ('/auth/token2Login', [AuthController::class, 'token2Login']);
+                $router->post('/auth/forget', [AuthController::class, 'forget']);
+                $router->post('/auth/getQuickLoginUrl', [AuthController::class, 'getQuickLoginUrl']);
+                $router->post('/auth/loginWithMailLink', [AuthController::class, 'loginWithMailLink']);
+            });
             // Comm
-            $router->post('/comm/sendEmailVerify', [CommController::class, 'sendEmailVerify']);
+            $router->post('/comm/sendEmailVerify', [CommController::class, 'sendEmailVerify'])->middleware('throttle:email-verify');
             $router->post('/comm/pv', [CommController::class, 'pv']);
         });
     }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,10 @@
 namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\RateLimiter;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -23,6 +26,12 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        //
+        RateLimiter::for('passport', function (Request $request) {
+            return Limit::perMinute(10)->by($request->ip());
+        });
+
+        RateLimiter::for('email-verify', function (Request $request) {
+            return Limit::perMinute(3)->by($request->ip());
+        });
     }
 }

--- a/app/Services/Auth/LoginService.php
+++ b/app/Services/Auth/LoginService.php
@@ -17,7 +17,7 @@ class LoginService
      * @param string $password 用户密码
      * @return array [成功状态, 用户对象或错误信息]
      */
-    public function login(string $email, string $password): array
+    public function login(string $email, string $password, ?string $ip = null): array
     {
         // 检查密码错误限制
         if ((int) admin_setting('password_limit_enable', true)) {
@@ -67,8 +67,11 @@ class LoginService
             return [false, [400, __('Your account has been suspended')]];
         }
 
-        // 更新最后登录时间
+        // 更新最后登录时间与 IP
         $user->last_login_at = time();
+        if ($ip !== null) {
+            $user->last_login_ip = $ip;
+        }
         $user->save();
 
         HookManager::call('user.login.after', $user);

--- a/app/Services/Auth/RegisterService.php
+++ b/app/Services/Auth/RegisterService.php
@@ -177,8 +177,10 @@ class RegisterService
             Cache::forget(CacheKey::get('EMAIL_VERIFY_CODE', $email));
         }
 
-        // 更新最近登录时间
+        // 更新最近登录时间与注册 IP（溯源/风控基础数据）
         $user->last_login_at = time();
+        $user->register_ip = $request->ip();
+        $user->last_login_ip = $request->ip();
         $user->save();
 
         // 更新IP注册计数

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -100,7 +100,14 @@ class OrderService
         HookManager::call('order.open.before', $order);
 
 
-        DB::transaction(function () use ($order, $plan) {
+        $opened = DB::transaction(function () use ($order, $plan) {
+            // 锁定订单行并复查状态：仅开通中可开通，防队列重派/回调并发重复入账（#1021 机制 B）
+            $locked = Order::lockForUpdate()->find($order->id);
+            if (!$locked || (int) $locked->status !== Order::STATUS_PROCESSING) {
+                return false;
+            }
+            $order->setRawAttributes($locked->getAttributes());
+
             $this->user = User::lockForUpdate()->find($order->user_id);
 
             if ($order->surplus_credit) {
@@ -129,7 +136,12 @@ class OrderService
             if (!$order->save()) {
                 throw new \RuntimeException('订单信息保存失败');
             }
+            return true;
         });
+
+        if (!$opened) {
+            return;
+        }
 
         $eventId = match ((int) $order->type) {
             Order::STATUS_PROCESSING => admin_setting('new_order_event_id', 0),
@@ -288,12 +300,19 @@ class OrderService
         $order = $this->order;
         if ($order->status !== Order::STATUS_PENDING)
             return true;
-        $order->status = Order::STATUS_PROCESSING;
-        $order->paid_at = time();
-        $order->callback_no = $callbackNo;
-        if (!$order->save())
-            return false;
         try {
+            // 仅允许从待支付原子迁移，并发回调只有一方成功（#1021 机制 B）
+            $updated = Order::where('id', $order->id)
+                ->where('status', Order::STATUS_PENDING)
+                ->update([
+                    'status' => Order::STATUS_PROCESSING,
+                    'paid_at' => time(),
+                    'callback_no' => $callbackNo,
+                ]);
+            if ($updated === 0) {
+                return true;
+            }
+            $order->refresh();
             OrderHandleJob::dispatchSync($order->trade_no);
         } catch (\Exception $e) {
             Log::error($e);
@@ -307,25 +326,32 @@ class OrderService
         $order = $this->order;
         HookManager::call('order.cancel.before', $order);
         try {
-            DB::beginTransaction();
-            $order->status = Order::STATUS_CANCELLED;
-            if (!$order->save()) {
-                throw new \Exception('Failed to save order status.');
-            }
-            if ($order->balance_amount) {
-                $userService = new UserService();
-                if (!$userService->addBalance($order->user_id, $order->balance_amount)) {
-                    throw new \Exception('Failed to add balance.');
+            $refunded = DB::transaction(function () use ($order) {
+                // 仅待支付可取消：条件更新保证状态迁移与退款最多一次（#1021 机制 A）
+                $updated = Order::where('id', $order->id)
+                    ->where('status', Order::STATUS_PENDING)
+                    ->update(['status' => Order::STATUS_CANCELLED]);
+                if ($updated === 0) {
+                    return false;
                 }
+                if ($order->balance_amount) {
+                    $userService = new UserService();
+                    if (!$userService->addBalance($order->user_id, $order->balance_amount)) {
+                        throw new \Exception('Failed to add balance.');
+                    }
+                }
+                return true;
+            });
+            if (!$refunded) {
+                return false;
             }
-            DB::commit();
-            HookManager::call('order.cancel.after', $order);
-            return true;
+            $order->status = Order::STATUS_CANCELLED;
         } catch (\Exception $e) {
-            DB::rollBack();
             Log::error($e);
             return false;
         }
+        HookManager::call('order.cancel.after', $order);
+        return true;
     }
 
     private function setSpeedLimit($speedLimit)

--- a/app/Support/Setting.php
+++ b/app/Support/Setting.php
@@ -16,7 +16,7 @@ class Setting
 
     public function __construct()
     {
-        $this->cache = Cache::store('redis');
+        $this->cache = Cache::store(config('cache.setting_store', 'redis'));
     }
 
     /**

--- a/config/admin.php
+++ b/config/admin.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    // Comma-separated IPs/CIDRs allowed to reach admin routes.
+    // Empty (default) disables the restriction.
+    // Example: ADMIN_IP_ALLOWLIST=1.2.3.4,10.0.0.0/8
+    'ip_allowlist' => env('ADMIN_IP_ALLOWLIST', ''),
+];

--- a/config/cache.php
+++ b/config/cache.php
@@ -20,6 +20,10 @@ return [
 
     'default' => env('CACHE_DRIVER', 'file'),
 
+    // Cache store for admin settings (App\Support\Setting).
+    // Defaults to redis in production; tests override with array.
+    'setting_store' => env('CACHE_SETTING_STORE', 'redis'),
+
     /*
     |--------------------------------------------------------------------------
     | Cache Stores

--- a/database/migrations/2026_08_24_000001_add_agent_version_to_server_machine.php
+++ b/database/migrations/2026_08_24_000001_add_agent_version_to_server_machine.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('v2_server_machine', function (Blueprint $table) {
+            $table->string('agent_version', 64)->nullable()->after('load_status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('v2_server_machine', function (Blueprint $table) {
+            $table->dropColumn('agent_version');
+        });
+    }
+};

--- a/database/migrations/2026_08_24_000002_add_register_ip_to_user.php
+++ b/database/migrations/2026_08_24_000002_add_register_ip_to_user.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('v2_user', function (Blueprint $table) {
+            $table->string('register_ip', 45)->nullable()->after('last_login_ip');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('v2_user', function (Blueprint $table) {
+            $table->dropColumn('register_ip');
+        });
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_DEBUG" value="true"/>
+        <env name="APP_KEY" value="base64:PZXk5vTuTinfeEVG5FpYv2l6WEhLsyvGpiWK7IgJJ60="/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="CACHE_SETTING_STORE" value="array"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="REDIS_CLIENT" value="phpredis"/>
+        <env name="REDIS_HOST" value="127.0.0.1"/>
+        <env name="REDIS_PORT" value="6379"/>
+    </php>
+</phpunit>

--- a/tests/Feature/Admin/AdminIpAllowlistTest.php
+++ b/tests/Feature/Admin/AdminIpAllowlistTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminIpAllowlistTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $adminPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->adminPath = '/api/v2/' . hash('crc32b', config('app.key'));
+    }
+
+    public function test_blocks_admin_requests_from_non_allowlisted_ip(): void
+    {
+        config()->set('admin.ip_allowlist', '10.99.99.99');
+
+        $response = $this->getJson($this->adminPath . '/config/fetch');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_allows_admin_requests_when_allowlist_empty(): void
+    {
+        config()->set('admin.ip_allowlist', '');
+
+        // Empty allowlist must not block; the 403 here comes from admin auth,
+        // not from the IP allowlist middleware.
+        $response = $this->getJson($this->adminPath . '/config/fetch');
+
+        $response->assertStatus(403)->assertJson(['message' => 'Unauthorized']);
+    }
+}

--- a/tests/Feature/Order/OrderCancelRaceTest.php
+++ b/tests/Feature/Order/OrderCancelRaceTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\Order;
+
+use App\Models\Order;
+use App\Models\Plan;
+use App\Models\User;
+use App\Services\OrderService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+// Regression tests for cedar2025/Xboard#1021:
+// concurrent/repeated cancellation of a pending order must refund the
+// balance deduction exactly once; repeated paid()/open() must not
+// double-credit or double-extend.
+class OrderCancelRaceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Plan $plan;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::create([
+            'email' => 'race@example.com',
+            'password' => password_hash('secret123', PASSWORD_DEFAULT),
+            'uuid' => Str::uuid()->toString(),
+            'token' => Str::random(32),
+            'balance' => 0,
+        ]);
+        $this->plan = Plan::create([
+            'group_id' => 1,
+            'transfer_enable' => 10,
+            'name' => 'test-plan',
+            'show' => 1,
+            'renew' => 1,
+            'sort' => 0,
+            'content' => '',
+            'speed_limit' => null,
+            'device_limit' => null,
+        ]);
+    }
+
+    private function pendingOrder(int $balanceAmount, int $totalAmount = 1000): Order
+    {
+        return Order::create([
+            'user_id' => $this->user->id,
+            'plan_id' => $this->plan->id,
+            'period' => 'month_price',
+            'trade_no' => 'TEST-' . Str::random(10),
+            'total_amount' => $totalAmount,
+            'balance_amount' => $balanceAmount,
+            'type' => Order::TYPE_NEW_PURCHASE,
+            'status' => Order::STATUS_PENDING,
+        ]);
+    }
+
+    public function test_second_cancel_does_not_refund_twice(): void
+    {
+        $order = $this->pendingOrder(500);
+
+        $first = (new OrderService($order))->cancel();
+        $this->assertTrue($first);
+        $this->assertSame(500, $this->user->refresh()->balance);
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->refresh()->status);
+
+        // Two concurrent requests both holding a stale pending model:
+        // the loser must not refund again.
+        $staleOrder = Order::find($order->id);
+        $staleOrder->status = Order::STATUS_PENDING;
+        $second = (new OrderService($staleOrder))->cancel();
+
+        $this->assertFalse($second);
+        $this->assertSame(500, $this->user->refresh()->balance);
+    }
+
+    public function test_cancel_after_paid_does_not_refund(): void
+    {
+        $order = $this->pendingOrder(500);
+        $order->status = Order::STATUS_PROCESSING;
+        $order->save();
+
+        // Stale controller-side model still believes the order is pending.
+        $staleOrder = Order::find($order->id);
+        $staleOrder->status = Order::STATUS_PENDING;
+
+        $result = (new OrderService($staleOrder))->cancel();
+
+        $this->assertFalse($result);
+        $this->assertSame(0, $this->user->refresh()->balance);
+        $this->assertSame(Order::STATUS_PROCESSING, (int) $order->refresh()->status);
+    }
+
+    public function test_paid_twice_opens_once(): void
+    {
+        $order = $this->pendingOrder(0, 0);
+        $service = new OrderService($order);
+
+        $this->assertTrue($service->paid('callback-1'));
+        $paidAt = $order->refresh()->paid_at;
+        $expiredAtAfterFirst = $this->user->refresh()->expired_at;
+
+        $this->assertTrue($service->paid('callback-2'));
+
+        $this->assertSame($paidAt, $order->refresh()->paid_at);
+        $this->assertSame($expiredAtAfterFirst, $this->user->refresh()->expired_at);
+        $this->assertSame(Order::STATUS_COMPLETED, (int) $order->refresh()->status);
+    }
+}

--- a/tests/Feature/Passport/IpTrackingTest.php
+++ b/tests/Feature/Passport/IpTrackingTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Passport;
+
+use App\Models\User;
+use App\Services\Auth\LoginService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+// IP tracking for anti-abuse (#1013): register_ip persisted on signup,
+// last_login_ip updated on every login.
+class IpTrackingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        admin_setting([
+            'email_verify' => 0,
+            'email_whitelist_enable' => 0,
+            'email_gmail_limit_enable' => 0,
+            'stop_register' => 0,
+            'invite_force' => 0,
+            'captcha_enable' => 0,
+            'register_limit_by_ip_enable' => 0,
+            'password_limit_enable' => 0,
+        ]);
+    }
+
+    private function registerRequest(string $email, string $ip = '1.2.3.4'): Request
+    {
+        $request = Request::create('/api/v1/passport/auth/register', 'POST', [
+            'email' => $email,
+            'password' => 'password123',
+        ]);
+        $request->server->set('REMOTE_ADDR', $ip);
+        $request->setUserResolver(fn () => null);
+        return $request;
+    }
+
+    public function test_register_records_register_ip(): void
+    {
+        $service = app(\App\Services\Auth\RegisterService::class);
+
+        [$ok, $user] = $service->register($this->registerRequest('ip-test@example.com', '9.9.9.9'));
+
+        $this->assertTrue((bool) $ok);
+        $this->assertSame('9.9.9.9', $user->refresh()->register_ip);
+    }
+
+    public function test_login_records_last_login_ip(): void
+    {
+        $user = User::create([
+            'email' => 'login-ip@example.com',
+            'password' => password_hash('password123', PASSWORD_DEFAULT),
+            'uuid' => Str::uuid()->toString(),
+            'token' => Str::random(32),
+        ]);
+
+        [$ok, $found] = app(LoginService::class)->login('login-ip@example.com', 'password123', '5.6.7.8');
+
+        $this->assertTrue((bool) $ok);
+        $this->assertSame('5.6.7.8', $found->refresh()->last_login_ip);
+    }
+}

--- a/tests/Feature/Passport/PassportRateLimitTest.php
+++ b/tests/Feature/Passport/PassportRateLimitTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Passport;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PassportRateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('app.key', 'base64:' . base64_encode(str_repeat('a', 32)));
+        admin_setting([
+            'stop_register' => 0,
+            'email_verify' => 0,
+            'captcha_enable' => 0,
+            'register_limit_by_ip_enable' => 0,
+            'password_login_enable' => 1,
+        ]);
+    }
+
+    public function test_login_is_rate_limited_after_10_attempts(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->postJson('/api/v1/passport/auth/login', [
+                'email' => 'nobody@example.com',
+                'password' => 'wrong-password',
+            ]);
+        }
+
+        $response = $this->postJson('/api/v1/passport/auth/login', [
+            'email' => 'nobody@example.com',
+            'password' => 'wrong-password',
+        ]);
+
+        $response->assertStatus(429);
+    }
+
+    public function test_send_email_verify_is_rate_limited_after_3_attempts(): void
+    {
+        for ($i = 0; $i < 3; $i++) {
+            $this->postJson('/api/v1/passport/comm/sendEmailVerify', [
+                'email' => 'nobody@example.com',
+            ]);
+        }
+
+        $response = $this->postJson('/api/v1/passport/comm/sendEmailVerify', [
+            'email' => 'nobody@example.com',
+        ]);
+
+        $response->assertStatus(429);
+    }
+}

--- a/tests/Feature/Server/MachineControlApiTest.php
+++ b/tests/Feature/Server/MachineControlApiTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Server;
+
+use App\Models\ServerMachine;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Redis;
+use Tests\TestCase;
+
+// Panel-side control channel: /server/machine/reload + /restart must publish
+// control.reload / control.restart to the WS Redis channel.
+class MachineControlApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $adminPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::forever('admin_settings', [
+            'server_token' => 'server-token',
+            'server_ws_enable' => 0,
+            'server_push_interval' => 60,
+        ]);
+        $this->adminPath = '/api/v2/' . hash('crc32b', config('app.key'));
+    }
+
+    private function admin(): User
+    {
+        return User::create([
+            'email' => 'admin@example.com',
+            'password' => password_hash('secret123', PASSWORD_DEFAULT),
+            'uuid' => \Illuminate\Support\Str::uuid()->toString(),
+            'token' => \Illuminate\Support\Str::random(32),
+            'is_admin' => 1,
+        ]);
+    }
+
+    public function test_reload_publishes_control_event_to_redis(): void
+    {
+        ServerMachine::create(['name' => 'm1', 'token' => 't1', 'is_active' => 1, 'last_seen_at' => now()->timestamp]);
+        $published = [];
+        Redis::shouldReceive('publish')->once()->andReturnUsing(function ($channel, $json) use (&$published) {
+            $this->assertSame('node:push', $channel);
+            $published = json_decode($json, true);
+        });
+
+        $this->actingAs($this->admin(), 'sanctum')
+            ->postJson($this->adminPath . '/server/machine/reload', ['machine_id' => 1, 'node_id' => 6])
+            ->assertOk()
+            ->assertJsonPath('data', true);
+
+        $this->assertSame(1, $published['machine_id']);
+        $this->assertSame('control.reload', $published['event']);
+        $this->assertSame(6, $published['data']['node_id']);
+    }
+
+    public function test_restart_without_node_id_targets_whole_machine(): void
+    {
+        ServerMachine::create(['name' => 'm1', 'token' => 't1', 'is_active' => 1, 'last_seen_at' => now()->timestamp]);
+        $published = [];
+        Redis::shouldReceive('publish')->once()->andReturnUsing(function ($channel, $json) use (&$published) {
+            $published = json_decode($json, true);
+        });
+
+        $this->actingAs($this->admin(), 'sanctum')
+            ->postJson($this->adminPath . '/server/machine/restart', ['machine_id' => 1])
+            ->assertOk();
+
+        $this->assertSame('control.restart', $published['event']);
+        $this->assertArrayNotHasKey('node_id', $published['data']);
+    }
+
+    public function test_control_rejected_for_inactive_machine(): void
+    {
+        ServerMachine::create(['name' => 'm1', 'token' => 't1', 'is_active' => 0, 'last_seen_at' => now()->timestamp]);
+        Redis::shouldReceive('publish')->never();
+
+        $this->actingAs($this->admin(), 'sanctum')
+            ->postJson($this->adminPath . '/server/machine/reload', ['machine_id' => 1])
+            ->assertStatus(400);
+    }
+}

--- a/tests/Feature/Server/MachineStatusVersionTest.php
+++ b/tests/Feature/Server/MachineStatusVersionTest.php
@@ -103,4 +103,27 @@ class MachineStatusVersionTest extends TestCase
         $machine->update(['last_seen_at' => now()->timestamp]);
         $this->artisan(CheckMachineOffline::class)->expectsOutputToContain('机器恢复')->assertSuccessful();
     }
+
+    public function test_high_load_alerts_after_sustained_rounds_and_recovers(): void
+    {
+        config()->set('cache.setting_store', 'array');
+        Cache::forget('machine_highload_rounds_1');
+        Cache::forget('machine_highload_alerted_1');
+
+        $machine = $this->machine([
+            'load_status' => ['cpu' => 95.0, 'mem' => ['total' => 1000, 'used' => 500]],
+        ]);
+
+        // 前 4 轮高负载：累计但不告警
+        for ($i = 0; $i < 4; $i++) {
+            $this->artisan(CheckMachineOffline::class)->assertSuccessful();
+        }
+
+        // 第 5 轮：触发告警
+        $this->artisan(CheckMachineOffline::class)->expectsOutputToContain('机器高负载')->assertSuccessful();
+
+        // 负载恢复：发恢复通知，且状态复位（再来高负载需重新累计）
+        $machine->update(['load_status' => ['cpu' => 10.0, 'mem' => ['total' => 1000, 'used' => 500]]]);
+        $this->artisan(CheckMachineOffline::class)->expectsOutputToContain('负载恢复')->assertSuccessful();
+    }
 }

--- a/tests/Feature/Server/MachineStatusVersionTest.php
+++ b/tests/Feature/Server/MachineStatusVersionTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature\Server;
+
+use App\Console\Commands\CheckMachineOffline;
+use App\Models\ServerMachine;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class MachineStatusVersionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::forever('admin_settings', [
+            'server_token' => 'server-token',
+            'server_ws_enable' => 0,
+            'server_push_interval' => 60,
+        ]);
+    }
+
+    private function machine(array $attrs = []): ServerMachine
+    {
+        return ServerMachine::create(array_merge([
+            'name' => 'test-machine',
+            'token' => 'machine-token',
+            'is_active' => 1,
+            'last_seen_at' => now()->timestamp,
+        ], $attrs));
+    }
+
+    public function test_machine_status_persists_agent_version(): void
+    {
+        $machine = $this->machine();
+
+        $response = $this->postJson('/api/v2/server/machine/status', [
+            'machine_id' => $machine->id,
+            'token' => 'machine-token',
+            'cpu' => 12.5,
+            'mem' => ['total' => 1000, 'used' => 500],
+            'agent_version' => 'v1.2.3-abc1234',
+        ]);
+
+        $response->assertOk();
+        $this->assertSame('v1.2.3-abc1234', $machine->refresh()->agent_version);
+    }
+
+    public function test_machine_status_without_version_keeps_old_value(): void
+    {
+        $machine = $this->machine(['agent_version' => 'v0.9.0']);
+
+        $this->postJson('/api/v2/server/machine/status', [
+            'machine_id' => $machine->id,
+            'token' => 'machine-token',
+            'cpu' => 10,
+            'mem' => ['total' => 1000, 'used' => 500],
+        ]);
+
+        $this->assertSame('v0.9.0', $machine->refresh()->agent_version);
+    }
+
+    public function test_admin_fetch_reports_online_state_and_version(): void
+    {
+        $online = $this->machine(['name' => 'online', 'agent_version' => 'v1.2.3']);
+        $offline = $this->machine([
+            'name' => 'offline',
+            'token' => 'tok2',
+            'last_seen_at' => now()->subSeconds(600)->timestamp,
+        ]);
+
+        $admin = \App\Models\User::create([
+            'email' => 'admin@example.com',
+            'password' => password_hash('secret123', PASSWORD_DEFAULT),
+            'uuid' => \Illuminate\Support\Str::uuid()->toString(),
+            'token' => \Illuminate\Support\Str::random(32),
+            'is_admin' => 1,
+        ]);
+
+        $response = $this->actingAs($admin, 'sanctum')
+            ->getJson('/api/v2/' . hash('crc32b', config('app.key')) . '/server/machine/fetch');
+
+        $response->assertOk();
+        $data = collect($response->json('data'))->keyBy('name');
+        $this->assertTrue($data['online']['is_online']);
+        $this->assertFalse($data['offline']['is_online']);
+        $this->assertSame('v1.2.3', $data['online']['agent_version']);
+    }
+
+    public function test_offline_alert_flips_once_per_state_change(): void
+    {
+        config()->set('cache.setting_store', 'array');
+        $machine = $this->machine(['last_seen_at' => now()->subSeconds(600)->timestamp]);
+
+        // 第一次：上线→离线，告警一次
+        $this->artisan(CheckMachineOffline::class)->expectsOutputToContain('机器离线')->assertSuccessful();
+        // 第二次：仍离线，不再告警
+        $this->artisan(CheckMachineOffline::class)->assertSuccessful();
+        // 心跳恢复 → 恢复通知
+        $machine->update(['last_seen_at' => now()->timestamp]);
+        $this->artisan(CheckMachineOffline::class)->expectsOutputToContain('机器恢复')->assertSuccessful();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    public function createApplication()
+    {
+        $app = require __DIR__ . '/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}


### PR DESCRIPTION
## Problem

Config changes on nodes wait for the agent's next pull interval, and restarts require SSH. Machine management was read-only (status, history, install commands) with no way to act.

## What

Two admin endpoints under `server/machine`:

- `POST /reload` — force node(s) to re-pull config (`node_id` scoped; omit for whole machine)
- `POST /restart` — restart a node in-process (`node_id`) or the agent process (omit `node_id`; graceful exit + systemd relaunch)

Rejected for inactive machines. Events ride the existing `pushMachine` → Redis → WS channel — **no worker-side changes needed**.

Agent-side implementation: cedar2025/Xboard-Node#72

## Testing

Feature tests: Redis publish assertions for both directives (event name, node_id scoping, machine_id routing) + inactive-machine guard. Live-verified end-to-end against a real agent (see Xboard-Node#72).