### PR TITLE
fix: ensure device IPs are encoded as JSON arrays

### DIFF
--- a/app/Services/DeviceStateService.php
+++ b/app/Services/DeviceStateService.php
@@ -162,7 +162,7 @@ class DeviceStateService
                     }
                 }
                 if (!empty($ips)) {
-                    $result[$userId] = array_unique($ips);
+                    $result[$userId] = array_values(array_unique($ips));
                 }
             }
         }


### PR DESCRIPTION
Fixes #907

`array_unique()` preserves the original keys. After duplicate IPs are removed,
the array may contain non-contiguous numeric indexes.

PHP's `json_encode()` serializes such arrays as JSON objects instead of arrays,
which can make xboard-node fail to decode the devices payload.

Reindex the result with `array_values()` to ensure device IPs are always
serialized as a JSON array.

```diff
- $result[$userId] = array_unique($ips);
+ $result[$userId] = array_values(array_unique($ips));