### PR TITLE
fix(plugin): autoload classes under plugins-core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,10 @@
         "psr-4": {
             "App\\": "app/",
             "Library\\": "library/",
-            "Plugin\\": "plugins/"
+            "Plugin\\": [
+                "plugins-core/",
+                "plugins/"
+            ]
         },
         "classmap": [
             "database/seeders",


### PR DESCRIPTION
Built-in plugins live in `plugins-core/`, but the `Plugin\` namespace is only mapped to `plugins/`.

`PluginManager::loadPlugin()` `require_once`'s `Plugin.php` directly, so the entry class still loads and the gap goes unnoticed — but any other class in a core plugin fails to resolve.

For example `plugins-core/AlipayF2f/Plugin.php` imports `Plugin\AlipayF2f\library\AlipayF2F`, which is not autoloadable:

```php
// plugins-core/AlipayF2f/Plugin.php
use Plugin\AlipayF2f\library\AlipayF2F;
```

This maps `Plugin\` to both `plugins-core/` and `plugins/`.

Verified with the two mappings side by side:

| `Plugin\` mapping | `class_exists('Plugin\AlipayF2f\library\AlipayF2F')` |
| --- | --- |
| `plugins/` only (current) | `false` |
| `plugins-core/` + `plugins/` | `true` |