### PR TITLE
改正流量量详情查询只返回当月数据的bug

### DIFF
--- a/app/Http/Controllers/V1/User/StatController.php
+++ b/app/Http/Controllers/V1/User/StatController.php
@@ -13,7 +13,7 @@ class StatController extends Controller
 {
     public function getTrafficLog(Request $request)
     {
-        $startDate = now()->startOfMonth()->timestamp;
+        $startDate = now()->subDays(31)->timestamp;
         $records = StatUser::query()
             ->where('user_id', $request->user()->id)
             ->where('record_at', '>=', $startDate)


### PR DESCRIPTION
流量量详情查询只返回当月数据，如果是月初只有几天的数据。改为返回过去30天数据。